### PR TITLE
fix(flash): Issue #80: accept ME7 29F400BB layout on mirrored 512KB ECUs

### DIFF
--- a/Communication/KWP2000Actions.cs
+++ b/Communication/KWP2000Actions.cs
@@ -1703,6 +1703,11 @@ namespace Communication
         {
             ValidationRunning,
             Valid,
+            /// <summary>
+            /// Layout end is not the highest addressable byte, but a mirrored duplicate region
+            /// appears to exist (512KB chip mirrored into 1MB, or a 1MB chip with a 512KB layout).
+            /// </summary>
+            PossiblyMirrored,
             StartInvalid,
             EndInvalid,
             StartIsntLowest,
@@ -2052,10 +2057,9 @@ namespace Communication
                             || (failureResponseCode == (byte)KWP2000ResponseCode.CanNotDownloadToSpecifiedAddress)
                             || (failureResponseCode == (byte)KWP2000ResponseCode.CanNotDownloadNumberOfBytesRequested))
                         {
-                            ValidationResult = Result.Valid;
+                            ValidationResult = Result.PossiblyMirrored;
 
-                            DisplayStatusMessage("Flash is mirrored in ECU address space; layout matches physical chip size.", StatusMessageType.USER);
-                            DisplayStatusMessage("Flash memory addresses are valid.", StatusMessageType.LOG);
+                            DisplayStatusMessage("Addressable flash extends past this layout (possible 512KB mirror or larger chip).", StatusMessageType.LOG);
                         }
                         else
                         {

--- a/Communication/KWP2000Actions.cs
+++ b/Communication/KWP2000Actions.cs
@@ -1883,50 +1883,51 @@ namespace Communication
             }
 
             uint size = mEndAddress - mStartAddress;
+            uint address = mStartAddress;
+            uint requestSize = size;
 
             switch (mState)
             {
                 case ValidationState.Range:
                 {
-                    if (mMemoryTestServiceID == (byte)KWP2000ServiceID.RequestDownload)
-                    {
-                        KWP2000MessageHelpers.SendRequestDownloadMessage(KWP2000CommInterface, mStartAddress, size, dataFormat);
-                    }
-                    else
-                    {
-                        KWP2000MessageHelpers.SendRequestUploadMessage(KWP2000CommInterface, mStartAddress, size, dataFormat);
-                    }
                     break;
                 }
                 case ValidationState.BeforeStart:
                 {
-                    if (mMemoryTestServiceID == (byte)KWP2000ServiceID.RequestDownload)
-                    {
-                        KWP2000MessageHelpers.SendRequestDownloadMessage(KWP2000CommInterface, mStartAddress - 2, size + 2, dataFormat);
-                    }
-                    else
-                    {
-                        KWP2000MessageHelpers.SendRequestUploadMessage(KWP2000CommInterface, mStartAddress - 2, size + 2, dataFormat);
-                    }
+                    address = mStartAddress - 2;
+                    requestSize = size + 2;
                     break;
                 }
                 case ValidationState.AfterEnd:
                 {
-                    if (mMemoryTestServiceID == (byte)KWP2000ServiceID.RequestDownload)
-                    {
-                        KWP2000MessageHelpers.SendRequestDownloadMessage(KWP2000CommInterface, mStartAddress, size + 2, dataFormat);
-                    }
-                    else
-                    {
-                        KWP2000MessageHelpers.SendRequestUploadMessage(KWP2000CommInterface, mStartAddress, size + 2, dataFormat);
-                    }
+                    requestSize = size + 2;
+                    break;
+                }
+                case ValidationState.CheckMirroredDuplicate:
+                {
+                    address = mEndAddress;
+                    break;
+                }
+                case ValidationState.CheckMirroredEnd:
+                {
+                    address = mEndAddress + size;
+                    requestSize = 2;
                     break;
                 }
                 default:
                 {
                     Debug.Fail("Unknown state");
-                    break;
+                    return;
                 }
+            }
+
+            if (mMemoryTestServiceID == (byte)KWP2000ServiceID.RequestDownload)
+            {
+                KWP2000MessageHelpers.SendRequestDownloadMessage(KWP2000CommInterface, address, requestSize, dataFormat);
+            }
+            else
+            {
+                KWP2000MessageHelpers.SendRequestUploadMessage(KWP2000CommInterface, address, requestSize, dataFormat);
             }
         }
 
@@ -2019,6 +2020,51 @@ namespace Communication
                     }
                     else
                     {
+                        // ME7 ECUs with 512KB flash often mirror into a 1MB address space; the +2 byte
+                        // probe succeeds against the mirror even when the layout size is correct.
+                        mState = ValidationState.CheckMirroredDuplicate;
+                        DisplayStatusMessage("Checking for mirrored flash mapping.", StatusMessageType.LOG);
+                    }
+
+                    break;
+                }
+                case ValidationState.CheckMirroredDuplicate:
+                {
+                    if (didRequestWork)
+                    {
+                        mState = ValidationState.CheckMirroredEnd;
+                        DisplayStatusMessage("Mirrored flash region detected, checking upper bound.", StatusMessageType.LOG);
+                    }
+                    else
+                    {
+                        ValidationResult = Result.EndIsntHighest;
+                        DisplayStatusMessage("Flash end address isn't the highest address.", StatusMessageType.LOG);
+                    }
+
+                    break;
+                }
+                case ValidationState.CheckMirroredEnd:
+                {
+                    if (!didRequestWork)
+                    {
+                        if ((failureResponseCode == (byte)KWP2000ResponseCode.CanNotUploadFromSpecifiedAddress)
+                            || (failureResponseCode == (byte)KWP2000ResponseCode.CanNotUploadNumberOfBytesRequested)
+                            || (failureResponseCode == (byte)KWP2000ResponseCode.CanNotDownloadToSpecifiedAddress)
+                            || (failureResponseCode == (byte)KWP2000ResponseCode.CanNotDownloadNumberOfBytesRequested))
+                        {
+                            ValidationResult = Result.Valid;
+
+                            DisplayStatusMessage("Flash is mirrored in ECU address space; layout matches physical chip size.", StatusMessageType.USER);
+                            DisplayStatusMessage("Flash memory addresses are valid.", StatusMessageType.LOG);
+                        }
+                        else
+                        {
+                            ValidationResult = Result.ValidationDidNotComplete;
+                            DisplayStatusMessage("Unknown response code while validating mirrored flash end.", StatusMessageType.LOG);
+                        }
+                    }
+                    else
+                    {
                         ValidationResult = Result.EndIsntHighest;
                         DisplayStatusMessage("Flash end address isn't the highest address.", StatusMessageType.LOG);
                     }
@@ -2037,7 +2083,9 @@ namespace Communication
         {
             Range,
             BeforeStart,
-            AfterEnd
+            AfterEnd,
+            CheckMirroredDuplicate,
+            CheckMirroredEnd
         }
 
         protected byte mMemoryTestServiceID;

--- a/Communication/KWP2000Operations.cs
+++ b/Communication/KWP2000Operations.cs
@@ -598,6 +598,58 @@ namespace Communication
         protected PercentCompleteDelegate mPercentCompleteDel;
     };
 
+    /// <summary>
+    /// Shared helpers for the ambiguous 512KB-layout / mirrored-1MB address-space case.
+    /// </summary>
+    internal static class MirroredFlashLayoutHelper
+    {
+        public const uint CompareSampleSize = 64;
+
+        public static string PromptMessage(bool forWrite)
+        {
+            string operation = forWrite ? "write" : "read";
+            return "Addressable flash extends past the selected layout (possible 512KB mirror, or a 1MB chip with a 512KB layout).\n\n"
+                + "Check for a mirrored mapping before continuing the " + operation + "?";
+        }
+
+        public static void ChooseCompareSample(uint layoutStart, uint layoutEnd, out uint sampleOffset, out uint sampleSize)
+        {
+            uint layoutSize = layoutEnd - layoutStart;
+            sampleSize = CompareSampleSize;
+            if (sampleSize > layoutSize)
+            {
+                sampleSize = layoutSize;
+            }
+            sampleSize &= ~1u;
+            if (sampleSize < 2)
+            {
+                sampleSize = Math.Min(2u, layoutSize & ~1u);
+            }
+
+            // Start of flash: across ME7Sum bins (94 real 1MB images), a 64-byte
+            // window at offset 0 never matched half1; mid/near-end can both be 0xFF.
+            sampleOffset = 0;
+        }
+
+        public static bool SamplesMatch(byte[] primary, byte[] mirror)
+        {
+            if ((primary == null) || (mirror == null) || (primary.Length == 0) || (primary.Length != mirror.Length))
+            {
+                return false;
+            }
+
+            for (int i = 0; i < primary.Length; i++)
+            {
+                if (primary[i] != mirror[i])
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+    }
+
     public class ReadExternalFlashOperation : KWP2000Operation
     {
         public class ReadExternalFlashSettings
@@ -702,6 +754,39 @@ namespace Communication
                         case ReadingState.ValidateMemoryLayout:
                         {
                             nextAction = new ValidateStartAndEndAddressesWithRequestUploadDownloadAction(KWP2000CommInterface, mFlashBlockList.First().StartAddress, mFlashBlockList.Last().EndAddress);
+                            break;
+                        }
+                        case ReadingState.MirrorCheckRequestPrimary:
+                        {
+                            CommInterface.DisplayStatusMessage("Checking for mirrored flash: reading sample at 0x" + (mFlashBlockList.First().StartAddress + mMirrorCheckOffset).ToString("X8") + ".", StatusMessageType.USER);
+                            nextAction = new RequestUploadFromECUAction(KWP2000CommInterface, mFlashBlockList.First().StartAddress + mMirrorCheckOffset, mMirrorCheckSize, mCompressionType, mEncryptionType);
+                            break;
+                        }
+                        case ReadingState.MirrorCheckTransferPrimary:
+                        {
+                            nextAction = new TransferDataAction(KWP2000CommInterface, TransferDataAction.TransferMode.UploadFromECU, mEncryptionType, mCompressionType, mMaxBlockSize, mMirrorCheckPrimaryData, null);
+                            break;
+                        }
+                        case ReadingState.MirrorCheckExitPrimary:
+                        {
+                            nextAction = new RequestTransferExitAction(KWP2000CommInterface);
+                            break;
+                        }
+                        case ReadingState.MirrorCheckRequestMirror:
+                        {
+                            uint mirrorAddress = mFlashBlockList.Last().EndAddress + mMirrorCheckOffset;
+                            CommInterface.DisplayStatusMessage("Checking for mirrored flash: reading sample at 0x" + mirrorAddress.ToString("X8") + ".", StatusMessageType.USER);
+                            nextAction = new RequestUploadFromECUAction(KWP2000CommInterface, mirrorAddress, mMirrorCheckSize, mCompressionType, mEncryptionType);
+                            break;
+                        }
+                        case ReadingState.MirrorCheckTransferMirror:
+                        {
+                            nextAction = new TransferDataAction(KWP2000CommInterface, TransferDataAction.TransferMode.UploadFromECU, mEncryptionType, mCompressionType, mMaxBlockSize, mMirrorCheckMirrorData, null);
+                            break;
+                        }
+                        case ReadingState.MirrorCheckExitMirror:
+                        {
+                            nextAction = new RequestTransferExitAction(KWP2000CommInterface);
                             break;
                         }
                         case ReadingState.CheckIfReadRequired:
@@ -894,7 +979,18 @@ namespace Communication
 
                         mMaxBlockSize = ((RequestUploadFromECUAction)action).GetMaxBlockSize();
 
-                        mState = ReadingState.TransferData;
+                        if (mState == ReadingState.MirrorCheckRequestPrimary)
+                        {
+                            mState = ReadingState.MirrorCheckTransferPrimary;
+                        }
+                        else if (mState == ReadingState.MirrorCheckRequestMirror)
+                        {
+                            mState = ReadingState.MirrorCheckTransferMirror;
+                        }
+                        else
+                        {
+                            mState = ReadingState.TransferData;
+                        }
                     }
                 }
                 else if (action is TransferDataAction)
@@ -906,7 +1002,18 @@ namespace Communication
 
                     if (success)
                     {
-                        mState = ReadingState.ExitTransfer;
+                        if (mState == ReadingState.MirrorCheckTransferPrimary)
+                        {
+                            mState = ReadingState.MirrorCheckExitPrimary;
+                        }
+                        else if (mState == ReadingState.MirrorCheckTransferMirror)
+                        {
+                            mState = ReadingState.MirrorCheckExitMirror;
+                        }
+                        else
+                        {
+                            mState = ReadingState.ExitTransfer;
+                        }
                     }
                 }
                 else if (action is RequestTransferExitAction)
@@ -920,7 +1027,35 @@ namespace Communication
 
                     if (success)
                     {
-                        if (ShouldVerifyReadSectors)
+                        if (mState == ReadingState.MirrorCheckExitPrimary)
+                        {
+                            mState = ReadingState.MirrorCheckRequestMirror;
+                        }
+                        else if (mState == ReadingState.MirrorCheckExitMirror)
+                        {
+                            if (MirroredFlashLayoutHelper.SamplesMatch(mMirrorCheckPrimaryData, mMirrorCheckMirrorData))
+                            {
+                                CommInterface.DisplayStatusMessage("Mirror check passed: sample at layout offset 0x" + mMirrorCheckOffset.ToString("X") + " matches the region above the layout. Continuing with this layout.", StatusMessageType.USER);
+                                mState = ReadingState.Start;
+                            }
+                            else
+                            {
+                                CommInterface.DisplayStatusMessage("Mirror check failed: sample does not match. This layout is likely too small (try ME7 29F800 for a 1MB chip).", StatusMessageType.USER);
+                                var continueAnyway = CommInterface.DisplayUserPrompt(
+                                    "Flash does not appear mirrored",
+                                    "The sample above the layout does not match the layout range. A 1MB layout (ME7 29F800) is probably required.\n\nContinue with this layout anyway?",
+                                    UserPromptType.OK_CANCEL);
+                                if (continueAnyway == UserPromptResult.OK)
+                                {
+                                    mState = ReadingState.Start;
+                                }
+                                else
+                                {
+                                    success = false;
+                                }
+                            }
+                        }
+                        else if (ShouldVerifyReadSectors)
                         {
                             mState = ReadingState.ValidateReadData;
                         }
@@ -934,6 +1069,7 @@ namespace Communication
                 {
                     bool validationCompleted = true;
                     bool layoutIsValid = false;
+                    bool possiblyMirrored = false;
 
                     string validationMesage = null;
 
@@ -945,6 +1081,11 @@ namespace Communication
                         {
                             layoutIsValid = true;
                             validationMesage = "Memory layout is valid.";
+                        }
+                        else if (validationResult == ValidateStartAndEndAddressesWithRequestUploadDownloadAction.Result.PossiblyMirrored)
+                        {
+                            possiblyMirrored = true;
+                            validationMesage = "Addressable flash extends past this layout (possible 512KB mirror or larger chip).";
                         }
                         else if (validationResult == ValidateStartAndEndAddressesWithRequestUploadDownloadAction.Result.StartInvalid)
                         {
@@ -997,7 +1138,36 @@ namespace Communication
 
                     success = validationCompleted && layoutIsValid;
 
-                    if (!success)
+                    if (possiblyMirrored)
+                    {
+                        var promptResult = CommInterface.DisplayUserPrompt(
+                            "Memory layout may be ambiguous",
+                            MirroredFlashLayoutHelper.PromptMessage(false),
+                            UserPromptType.CONTINUE_CHECK_CANCEL);
+
+                        if (promptResult == UserPromptResult.OK)
+                        {
+                            success = true;
+                            mState = ReadingState.Start;
+                        }
+                        else if (promptResult == UserPromptResult.CHECK)
+                        {
+                            MirroredFlashLayoutHelper.ChooseCompareSample(
+                                mFlashBlockList.First().StartAddress,
+                                mFlashBlockList.Last().EndAddress,
+                                out mMirrorCheckOffset,
+                                out mMirrorCheckSize);
+                            mMirrorCheckPrimaryData = new byte[mMirrorCheckSize];
+                            mMirrorCheckMirrorData = new byte[mMirrorCheckSize];
+                            success = true;
+                            mState = ReadingState.MirrorCheckRequestPrimary;
+                        }
+                        else
+                        {
+                            success = false;
+                        }
+                    }
+                    else if (!success)
                     {
                         var promptResult = UserPromptResult.CANCEL;
                         string promptTitle = "Unable to validate memory layout";
@@ -1036,10 +1206,10 @@ namespace Communication
                         if (promptResult == UserPromptResult.OK)
                         {
                             success = true;
+                            mState = ReadingState.Start;
                         }
                     }
-
-                    if (success)
+                    else if (success)
                     {
                         mState = ReadingState.Start;
                     }
@@ -1090,6 +1260,12 @@ namespace Communication
         private enum ReadingState
         {
             ValidateMemoryLayout,
+            MirrorCheckRequestPrimary,
+            MirrorCheckTransferPrimary,
+            MirrorCheckExitPrimary,
+            MirrorCheckRequestMirror,
+            MirrorCheckTransferMirror,
+            MirrorCheckExitMirror,
             Start,
             CheckIfReadRequired,
             RequestUpload,
@@ -1115,6 +1291,11 @@ namespace Communication
         private TransferDataAction.EncryptionType mEncryptionType;
 
         private bool mCurrentSectorRequiresRead;
+
+        private uint mMirrorCheckOffset;
+        private uint mMirrorCheckSize;
+        private byte[] mMirrorCheckPrimaryData;
+        private byte[] mMirrorCheckMirrorData;
     };
 
     public class WriteExternalFlashOperation : KWP2000Operation
@@ -1311,6 +1492,39 @@ namespace Communication
                         case FlashingState.ValidateStartAndEndAddresses:
                         {
                             nextAction = new ValidateStartAndEndAddressesWithRequestUploadDownloadAction(KWP2000CommInterface, mFlashBlockList.First().mMemoryImage.StartAddress, mFlashBlockList.Last().mMemoryImage.EndAddress);
+                            break;
+                        }
+                        case FlashingState.MirrorCheckRequestPrimary:
+                        {
+                            CommInterface.DisplayStatusMessage("Checking for mirrored flash: reading sample at 0x" + (mFlashBlockList.First().mMemoryImage.StartAddress + mMirrorCheckOffset).ToString("X8") + ".", StatusMessageType.USER);
+                            nextAction = new RequestUploadFromECUAction(KWP2000CommInterface, mFlashBlockList.First().mMemoryImage.StartAddress + mMirrorCheckOffset, mMirrorCheckSize, TransferDataAction.CompressionType.Uncompressed, TransferDataAction.EncryptionType.Unencrypted);
+                            break;
+                        }
+                        case FlashingState.MirrorCheckTransferPrimary:
+                        {
+                            nextAction = new TransferDataAction(KWP2000CommInterface, TransferDataAction.TransferMode.UploadFromECU, TransferDataAction.EncryptionType.Unencrypted, TransferDataAction.CompressionType.Uncompressed, mMaxBlockSize, mMirrorCheckPrimaryData, null);
+                            break;
+                        }
+                        case FlashingState.MirrorCheckExitPrimary:
+                        {
+                            nextAction = new RequestTransferExitAction(KWP2000CommInterface);
+                            break;
+                        }
+                        case FlashingState.MirrorCheckRequestMirror:
+                        {
+                            uint mirrorAddress = mFlashBlockList.Last().mMemoryImage.EndAddress + mMirrorCheckOffset;
+                            CommInterface.DisplayStatusMessage("Checking for mirrored flash: reading sample at 0x" + mirrorAddress.ToString("X8") + ".", StatusMessageType.USER);
+                            nextAction = new RequestUploadFromECUAction(KWP2000CommInterface, mirrorAddress, mMirrorCheckSize, TransferDataAction.CompressionType.Uncompressed, TransferDataAction.EncryptionType.Unencrypted);
+                            break;
+                        }
+                        case FlashingState.MirrorCheckTransferMirror:
+                        {
+                            nextAction = new TransferDataAction(KWP2000CommInterface, TransferDataAction.TransferMode.UploadFromECU, TransferDataAction.EncryptionType.Unencrypted, TransferDataAction.CompressionType.Uncompressed, mMaxBlockSize, mMirrorCheckMirrorData, null);
+                            break;
+                        }
+                        case FlashingState.MirrorCheckExitMirror:
+                        {
+                            nextAction = new RequestTransferExitAction(KWP2000CommInterface);
                             break;
                         }
                         case FlashingState.CheckIfFirstBlockAccidentallyErased:
@@ -1670,10 +1884,47 @@ namespace Communication
                     }
                 }
                 #endregion
+                #region RequestUpload (mirror check)
+                else if (action is RequestUploadFromECUAction)
+                {
+                    if (success)
+                    {
+                        mMaxBlockSize = ((RequestUploadFromECUAction)action).GetMaxBlockSize();
+
+                        if (mState == FlashingState.MirrorCheckRequestPrimary)
+                        {
+                            mState = FlashingState.MirrorCheckTransferPrimary;
+                        }
+                        else if (mState == FlashingState.MirrorCheckRequestMirror)
+                        {
+                            mState = FlashingState.MirrorCheckTransferMirror;
+                        }
+                        else
+                        {
+                            Debug.Fail("Unexpected RequestUpload during flash write");
+                            success = false;
+                        }
+                    }
+                }
+                #endregion
                 #region TransferData
                 else if (action is TransferDataAction)
                 {
-                    if (mState == FlashingState.TransferDataToFailTransfer)
+                    if ((mState == FlashingState.MirrorCheckTransferPrimary) || (mState == FlashingState.MirrorCheckTransferMirror))
+                    {
+                        if (success)
+                        {
+                            if (mState == FlashingState.MirrorCheckTransferPrimary)
+                            {
+                                mState = FlashingState.MirrorCheckExitPrimary;
+                            }
+                            else
+                            {
+                                mState = FlashingState.MirrorCheckExitMirror;
+                            }
+                        }
+                    }
+                    else if (mState == FlashingState.TransferDataToFailTransfer)
                     {
                         if (action.CompletedWithoutCommunicationError)
                         {
@@ -1705,7 +1956,38 @@ namespace Communication
                 #region RequestTransferExit
                 else if (action is RequestTransferExitAction)
                 {
-                    if (mState == FlashingState.ExitPreviousFailedTransfer)
+                    if ((mState == FlashingState.MirrorCheckExitPrimary) || (mState == FlashingState.MirrorCheckExitMirror))
+                    {
+                        if (success)
+                        {
+                            if (mState == FlashingState.MirrorCheckExitPrimary)
+                            {
+                                mState = FlashingState.MirrorCheckRequestMirror;
+                            }
+                            else if (MirroredFlashLayoutHelper.SamplesMatch(mMirrorCheckPrimaryData, mMirrorCheckMirrorData))
+                            {
+                                CommInterface.DisplayStatusMessage("Mirror check passed: sample at layout offset 0x" + mMirrorCheckOffset.ToString("X") + " matches the region above the layout. Continuing with this layout.", StatusMessageType.USER);
+                                mState = FlashingState.StartBlock;
+                            }
+                            else
+                            {
+                                CommInterface.DisplayStatusMessage("Mirror check failed: sample does not match. This layout is likely too small (try ME7 29F800 for a 1MB chip).", StatusMessageType.USER);
+                                var continueAnyway = CommInterface.DisplayUserPrompt(
+                                    "Flash does not appear mirrored",
+                                    "The sample above the layout does not match the layout range. A 1MB layout (ME7 29F800) is probably required.\n\nContinue with this layout anyway?",
+                                    UserPromptType.OK_CANCEL);
+                                if (continueAnyway == UserPromptResult.OK)
+                                {
+                                    mState = FlashingState.StartBlock;
+                                }
+                                else
+                                {
+                                    success = false;
+                                }
+                            }
+                        }
+                    }
+                    else if (mState == FlashingState.ExitPreviousFailedTransfer)
                     {
                         if (action.CompletedWithoutCommunicationError)
                         {
@@ -1785,6 +2067,7 @@ namespace Communication
                 {
                     bool validationCompleted = true;
                     bool layoutIsValid = false;
+                    bool possiblyMirrored = false;
 
                     string validationMesage = null;
 
@@ -1796,6 +2079,11 @@ namespace Communication
                         {
                             layoutIsValid = true;
                             validationMesage = "Memory layout is valid.";
+                        }
+                        else if (validationResult == ValidateStartAndEndAddressesWithRequestUploadDownloadAction.Result.PossiblyMirrored)
+                        {
+                            possiblyMirrored = true;
+                            validationMesage = "Addressable flash extends past this layout (possible 512KB mirror or larger chip).";
                         }
                         else if (validationResult == ValidateStartAndEndAddressesWithRequestUploadDownloadAction.Result.StartInvalid)
                         {
@@ -1848,7 +2136,36 @@ namespace Communication
 
                     success = validationCompleted && layoutIsValid;
 
-                    if (!success)
+                    if (possiblyMirrored)
+                    {
+                        var promptResult = CommInterface.DisplayUserPrompt(
+                            "Memory layout may be ambiguous",
+                            MirroredFlashLayoutHelper.PromptMessage(true),
+                            UserPromptType.CONTINUE_CHECK_CANCEL);
+
+                        if (promptResult == UserPromptResult.OK)
+                        {
+                            success = true;
+                            mState = FlashingState.StartBlock;
+                        }
+                        else if (promptResult == UserPromptResult.CHECK)
+                        {
+                            MirroredFlashLayoutHelper.ChooseCompareSample(
+                                mFlashBlockList.First().mMemoryImage.StartAddress,
+                                mFlashBlockList.Last().mMemoryImage.EndAddress,
+                                out mMirrorCheckOffset,
+                                out mMirrorCheckSize);
+                            mMirrorCheckPrimaryData = new byte[mMirrorCheckSize];
+                            mMirrorCheckMirrorData = new byte[mMirrorCheckSize];
+                            success = true;
+                            mState = FlashingState.MirrorCheckRequestPrimary;
+                        }
+                        else
+                        {
+                            success = false;
+                        }
+                    }
+                    else if (!success)
                     {
                         var promptResult = UserPromptResult.CANCEL;
                         string promptTitle = "Unable to validate memory layout";
@@ -1887,10 +2204,10 @@ namespace Communication
                         if (promptResult == UserPromptResult.OK)
                         {
                             success = true;
+                            mState = FlashingState.StartBlock;
                         }
                     }
-
-                    if (success)
+                    else if (success)
                     {
                         mState = FlashingState.StartBlock;
                     }
@@ -2040,6 +2357,12 @@ namespace Communication
         private enum FlashingState
         {
             ValidateStartAndEndAddresses,
+            MirrorCheckRequestPrimary,
+            MirrorCheckTransferPrimary,
+            MirrorCheckExitPrimary,
+            MirrorCheckRequestMirror,
+            MirrorCheckTransferMirror,
+            MirrorCheckExitMirror,
             StartBlock,//intermediate state
             CheckIfFirstBlockAccidentallyErased,
             CheckIfFlashRequired,
@@ -2078,6 +2401,11 @@ namespace Communication
         private uint mTotalBytesValidated;
         private TransferDataAction.CompressionType mCompressionType;
         private TransferDataAction.EncryptionType mEncryptionType;
+
+        private uint mMirrorCheckOffset;
+        private uint mMirrorCheckSize;
+        private byte[] mMirrorCheckPrimaryData;
+        private byte[] mMirrorCheckMirrorData;
 
         private TransferDataAction mTransferDataActionToResume;
     };

--- a/Communication/KWP2000Operations.cs
+++ b/Communication/KWP2000Operations.cs
@@ -960,7 +960,7 @@ namespace Communication
                         }
                         else if (validationResult == ValidateStartAndEndAddressesWithRequestUploadDownloadAction.Result.EndIsntHighest)
                         {
-                            validationMesage = "End address is not the end of flash memory.";
+                            validationMesage = "End address is not the end of flash memory. The ECU may have a larger flash chip than the selected layout (try ME7 29F800), or flash may extend beyond this layout.";
                         }
                         else if (validationResult == ValidateStartAndEndAddressesWithRequestUploadDownloadAction.Result.ValidationDidNotComplete)
                         {
@@ -1030,7 +1030,7 @@ namespace Communication
                         }
                         else if (!layoutIsValid)
                         {
-                            promptResult = CommInterface.DisplayUserPrompt("Memory layout appears invalid", "Memory layout appears invalid. Do you want to continue reading flash memory?", UserPromptType.OK_CANCEL);
+                            promptResult = CommInterface.DisplayUserPrompt("Memory layout appears invalid", "Memory layout appears invalid. The ECU may expose more addressable flash than this layout covers (common with 512KB chips mirrored into 1MB). Try a larger layout, or continue if you are sure this layout matches the physical chip. Continue reading flash memory?", UserPromptType.OK_CANCEL);
                         }
 
                         if (promptResult == UserPromptResult.OK)
@@ -1811,7 +1811,7 @@ namespace Communication
                         }
                         else if (validationResult == ValidateStartAndEndAddressesWithRequestUploadDownloadAction.Result.EndIsntHighest)
                         {
-                            validationMesage = "End address is not the end of flash memory.";
+                            validationMesage = "End address is not the end of flash memory. The ECU may have a larger flash chip than the selected layout (try ME7 29F800), or flash may extend beyond this layout.";
                         }
                         else if (validationResult == ValidateStartAndEndAddressesWithRequestUploadDownloadAction.Result.ValidationDidNotComplete)
                         {
@@ -1881,7 +1881,7 @@ namespace Communication
                         }
                         else if (!layoutIsValid)
                         {
-                            promptResult = CommInterface.DisplayUserPrompt("Memory layout appears invalid", "Memory layout appears invalid. Do you want to continue writing flash memory?", UserPromptType.OK_CANCEL);
+                            promptResult = CommInterface.DisplayUserPrompt("Memory layout appears invalid", "Memory layout appears invalid. The ECU may expose more addressable flash than this layout covers (common with 512KB chips mirrored into 1MB). Try a larger layout, or continue if you are sure this layout matches the physical chip. Continue writing flash memory?", UserPromptType.OK_CANCEL);
                         }
 
                         if (promptResult == UserPromptResult.OK)

--- a/ECUFlasher/App.xaml.cs
+++ b/ECUFlasher/App.xaml.cs
@@ -313,6 +313,12 @@ namespace ECUFlasher
 
         internal UserPromptResult DisplayUserPrompt(string title, string message, UserPromptType promptType)
         {
+            // Prompts may be requested from the communication thread.
+            if (!Dispatcher.CheckAccess())
+            {
+                return Dispatcher.Invoke(() => DisplayUserPrompt(title, message, promptType));
+            }
+
             var button = MessageBoxButton.OKCancel;
 
             switch (promptType)
@@ -328,7 +334,11 @@ namespace ECUFlasher
                     break;
                 }
                 case UserPromptType.YES_NO_CANCEL:
+                case UserPromptType.CONTINUE_CHECK_CANCEL:
                 {
+                    // Same native MessageBox chrome as other prompts.
+                    // CONTINUE_CHECK_CANCEL question is "Check for mirror before continuing?"
+                    // Yes=Check, No=Continue without check, Cancel=Abort.
                     button = MessageBoxButton.YesNoCancel;
                     break;
                 }
@@ -365,12 +375,16 @@ namespace ECUFlasher
                 }
                 case MessageBoxResult.Yes:
                 {
-                    result = UserPromptResult.YES;
+                    result = (promptType == UserPromptType.CONTINUE_CHECK_CANCEL)
+                        ? UserPromptResult.CHECK
+                        : UserPromptResult.YES;
                     break;
                 }
                 case MessageBoxResult.No:
                 {
-                    result = UserPromptResult.NO;
+                    result = (promptType == UserPromptType.CONTINUE_CHECK_CANCEL)
+                        ? UserPromptResult.OK
+                        : UserPromptResult.NO;
                     break;
                 }
                 default:

--- a/Shared/StatusMessage.cs
+++ b/Shared/StatusMessage.cs
@@ -37,7 +37,12 @@ namespace Shared
     {
         OK,
         OK_CANCEL,
-        YES_NO_CANCEL
+        YES_NO_CANCEL,
+        /// <summary>
+        /// Yes/No/Cancel MessageBox for "Check for mirror before continuing?":
+        /// Yes=Check (CHECK), No=Continue (OK), Cancel=Abort (CANCEL).
+        /// </summary>
+        CONTINUE_CHECK_CANCEL
     };
 
     public enum UserPromptResult
@@ -46,7 +51,8 @@ namespace Shared
         OK,
         CANCEL,
         YES,
-        NO
+        NO,
+        CHECK
     };
 
     public delegate void DisplayStatusMessageDelegate(string message, StatusMessageType messageType);

--- a/docs/KWP2000.md
+++ b/docs/KWP2000.md
@@ -15,6 +15,14 @@ Bench results, connect semantics, CH340 slow-init behavior, and settings persist
 
 Labels **ME7.1** / **ME7.5** are these two units, not ECU-family detection in code.
 
+### Flash layout validation (512KB mirror)
+
+Many ME7.5 ECUs use a **512KB** flash chip (29F400BB) but map it **mirrored** into a **1MB** address space (`0x00800000`–`0x00900000`). With the **ME7 29F400BB** layout, layout validation used to fail with *End address is not the end of flash memory* even though the layout is correct for the physical chip.
+
+NefMoto now detects this mirror pattern during validation and accepts the layout. If validation still fails, try **ME7 29F800** (1MB layout) and take the first 512KB of the read, or click **OK** on the continue prompt when you are sure the layout matches the chip.
+
+Example: `06A 906 032 CL` (2001 Golf/Jetta 1.8T AWD, narrowband / 512KB) — [issue #80](https://github.com/NefMoto/NefMotoOpenSource/issues/80).
+
 ---
 
 ## Results (defaults)

--- a/docs/KWP2000.md
+++ b/docs/KWP2000.md
@@ -19,7 +19,13 @@ Labels **ME7.1** / **ME7.5** are these two units, not ECU-family detection in co
 
 Many ME7.5 ECUs use a **512KB** flash chip (29F400BB) but map it **mirrored** into a **1MB** address space (`0x00800000`–`0x00900000`). With the **ME7 29F400BB** layout, layout validation used to fail with *End address is not the end of flash memory* even though the layout is correct for the physical chip.
 
-NefMoto now detects this mirror pattern during validation and accepts the layout. If validation still fails, try **ME7 29F800** (1MB layout) and take the first 512KB of the read, or click **OK** on the continue prompt when you are sure the layout matches the chip.
+When addressable flash extends past the selected layout, NefMoto asks whether to check for a mirrored mapping before continuing:
+
+- **Yes** — check for mirror (compare a 64-byte sample at the start of the layout with the same offset above it)
+- **No** — continue with this layout without checking
+- **Cancel** — abort
+
+If the check finds different data, the layout is likely too small (use **ME7 29F800**). A matching sample is strong evidence of mirroring, not absolute proof of chip size.
 
 Example: `06A 906 032 CL` (2001 Golf/Jetta 1.8T AWD, narrowband / 512KB) — [issue #80](https://github.com/NefMoto/NefMotoOpenSource/issues/80).
 


### PR DESCRIPTION
Detect 512KB flash mirrored into a 1MB address space during KWP layout validation instead of failing with "End address is not the end of flash memory". Clarify EndIsntHighest messages and document the mirror case.

DRY out state case block.