### PR TITLE
fix(kwp): Issue #95: accept missing slow-init address complement

### DIFF
--- a/Communication/KWP2000Interface.cs
+++ b/Communication/KWP2000Interface.cs
@@ -1846,28 +1846,42 @@ namespace Communication
                             }
                         }
 
-                        //need to read the address complement if this slow init started a KWP2000 session
+                        // ISO 14230-2 W4: ECU should send inverted address. Some Bosch images
+                        // (e.g. 06A906032HN) never do after valid KWP2000 keys. 0-byte timeout:
+                        // continue. Wrong byte: fail. See issue #95.
                         if (result && IsKeyByte1ValidKWP2000(keyByte1, false) && IsKeyByte2ValidKWP2000(keyByte2, false))
                         {
                             success &= mCommunicationDevice.SetDataCharacteristics(DataBits.Bits8, StopBits.Bits1, Parity.None);
+                            // FTDI Read waits SetTimeouts per attempt; apply W4 window so we do not wait DeviceReadTimeOutMs (~1-2 s)
+                            success &= mCommunicationDevice.SetTimeouts(SLOW_INIT_ADDRESS_COMPLEMENT_READ_TIMEOUT_MS, FTDIDeviceWriteTimeOutMs);
 
                             LogSlowInitHandshakePhase("address complement read start");
 
                             //read the complement of the address
                             byte[] addressComplement = new byte[1];
                             uint numBytesRead = 0;
-                            success &= mCommunicationDevice.Read(addressComplement, (uint)addressComplement.Length, ref numBytesRead, SLOW_INIT_ADDRESS_COMPLEMENT_READ_TIMEOUT_MS);
+                            bool complementReadOk = mCommunicationDevice.Read(addressComplement, (uint)addressComplement.Length, ref numBytesRead, SLOW_INIT_ADDRESS_COMPLEMENT_READ_TIMEOUT_MS);
+                            success &= complementReadOk;
+
+                            byte expectedComplement = (byte)~connectAddress;
+                            bool complementMatched = complementReadOk && (numBytesRead == addressComplement.Length) && (addressComplement[0] == expectedComplement);
+                            bool complementAbsent = complementReadOk && (numBytesRead == 0);
 
                             LogSlowInitHandshakePhase("address complement read done",
                                 numBytesRead > 0 ? addressComplement[0] : null,
-                                success && (numBytesRead == addressComplement.Length) && (addressComplement[0] == (byte)~connectAddress));
+                                complementMatched || complementAbsent);
 
-                            DisplayStatusMessage("Slow init address complement read: success=" + success
+                            DisplayStatusMessage("Slow init address complement read: success=" + complementReadOk
                                 + ", read=" + numBytesRead
                                 + ", value=0x" + (numBytesRead > 0 ? addressComplement[0].ToString("X2") : "??")
-                                + ", expected=0x" + ((byte)~connectAddress).ToString("X2") + ".", StatusMessageType.LOG);
+                                + ", expected=0x" + expectedComplement.ToString("X2") + ".", StatusMessageType.LOG);
 
-                            if (!success || (numBytesRead != addressComplement.Length) || (addressComplement[0] != (byte)~connectAddress))
+                            if (complementAbsent)
+                            {
+                                DisplayStatusMessage("Slow init: no address complement (0 bytes, expected 0x"
+                                    + expectedComplement.ToString("X2") + "); continuing.", StatusMessageType.LOG);
+                            }
+                            else if (!complementMatched)
                             {
                                 result = false;
                                 DisplayStatusMessage("Failed to read address complement.", StatusMessageType.LOG);

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Open-source tool for reading, writing, and tuning VW/Audi ME7 ECUs via KWP2000
 
 - **ME7.x** - Primary target; full KWP2000 and bootmode support
 - **ME7.5 fast init** - Not supported on one bench unit after address and timing sweeps. Use **slow init** instead. Other ME7.5 images may differ. See [docs/KWP2000.md](docs/KWP2000.md)
+- Some ME7 images (e.g. `06A906032HN`) omit the ISO inverted-address byte after KWP2000 slow init; NefMoto continues if that byte is absent. See [docs/KWP2000.md](docs/KWP2000.md)
 - **Simos 3.x / EDC15** - Bootmode support (layout auto-detect)
 - Memory layouts provided for common flash chips (29F200, 29F400, 29F800 series)
 - Some ECUs may require specific connection parameters or timing adjustments

--- a/docs/KWP2000.md
+++ b/docs/KWP2000.md
@@ -98,6 +98,23 @@ Legacy **`AllowCh340SlowInit`** is removed (ignored in old user.config). CH340 s
 
 ---
 
+## Slow init address complement
+
+ISO 14230-2: after the tester sends inverted key byte 2, the ECU should send inverted address (W4, 25–50 ms).
+
+Bench ME7.1 (`8D0907551M`) and ME7.5 (`4B0906018CH`) send that byte. Some Bosch images (field: `06A906032HN`) advertise KWP2000 (`KB1=0x6F KB2=0x0F`) and never send it.
+
+NefMoto:
+
+- Times out at 100 ms (W4Max + USB margin). FTDI `SetTimeouts` is applied so the read does not wait `DeviceReadTimeOutMs` (~1–2 s)
+- **0 bytes:** log and continue (session already named by key bytes)
+- **Wrong byte:** fail (desync / collision)
+- No user option (same as removed `AllowCh340SlowInit`)
+
+Verify with a real KWP2000 request after connect, not only “Slow init succeeded.” [Issue #95](https://github.com/NefMoto/NefMotoOpenSource/issues/95).
+
+---
+
 ## Bench checklist
 
 - Adapter in dumb mode; K-line direct to ECU; stable power
@@ -112,3 +129,4 @@ Legacy **`AllowCh340SlowInit`** is removed (ignored in old user.config). CH340 s
 - [README.md](../README.md)
 - [issue #76](https://github.com/NefMoto/NefMotoOpenSource/issues/76) — CH340 slow init
 - [issue #44](https://github.com/NefMoto/NefMotoOpenSource/issues/44) — CH340 bootmode baud
+- [issue #95](https://github.com/NefMoto/NefMotoOpenSource/issues/95) — missing KWP2000 address complement


### PR DESCRIPTION
Some Bosch images (06A906032HN) advertise KWP2000 with valid key bytes and never send the ISO inverted address. Treating a 0-byte timeout as a hard fail aborted an otherwise complete handshake.

Continue when the complement read times out empty; still fail on a wrong byte. Apply the 100 ms timeout via SetTimeouts so FTDI does not wait DeviceReadTimeOutMs (~1-2 s).

Fixes #95.