### PR TITLE
fix(kwp): Issue #95: skip redundant 8N1 switch before address complement, remove extraneous code from critical W4 section

### DIFF
--- a/Communication/KWP2000Interface.cs
+++ b/Communication/KWP2000Interface.cs
@@ -1783,6 +1783,10 @@ namespace Communication
 
                                             if (success)
                                             {
+                                                DisplayStatusMessage("Slow init key byte complement echo: 0x"
+                                                    + echo[0].ToString("X2")
+                                                    + " (expected 0x" + keyByteComp[0].ToString("X2") + ").",
+                                                    StatusMessageType.LOG);
                                                 if (echo[0] == keyByteComp[0])
                                                 {
                                                     result = true;
@@ -1847,9 +1851,9 @@ namespace Communication
                         }
 
                         //need to read the address complement if this slow init started a KWP2000 session
+                        // UART is already 8N1 from connect; do not SetDataCharacteristics here (issue #95 / 1.9.4.3)
                         if (result && IsKeyByte1ValidKWP2000(keyByte1, false) && IsKeyByte2ValidKWP2000(keyByte2, false))
                         {
-                            success &= mCommunicationDevice.SetDataCharacteristics(DataBits.Bits8, StopBits.Bits1, Parity.None);
                             // FTDI Read waits SetTimeouts per attempt; apply W4 window so we do not wait DeviceReadTimeOutMs (~1-2 s)
                             success &= mCommunicationDevice.SetTimeouts(SLOW_INIT_ADDRESS_COMPLEMENT_READ_TIMEOUT_MS, FTDIDeviceWriteTimeOutMs);
 

--- a/Communication/KWP2000Interface.cs
+++ b/Communication/KWP2000Interface.cs
@@ -1710,7 +1710,7 @@ namespace Communication
                                 long lastReadTime = 0;
                                 uint keyByteTimeOut = (uint)SlowInitConnectionTiming.W2Max;
                                 uint lastChanceKeyByteTimeOut = keyByteTimeOut * 2;
-                                //keep reading key bytes until we hit the time out, but if we don't have at least 2 keep reading until double the time out
+                                // Stop once two key bytes are in. Waiting W3Max for a third burns most of ISO W4 (issue #95).
                                 do
                                 {
                                     lastReadTime = watch.ElapsedMilliseconds;
@@ -1733,37 +1733,30 @@ namespace Communication
                                             for (int x = 0; x < numBytesRead; ++x)
                                             {
                                                 keyBytes.Add(keyByteData[x]);
-                                                DisplayStatusMessage("Slow init key byte raw[" + (keyBytes.Count - 1) + "]=0x"
-                                                    + keyByteData[x].ToString("X2") + ".", StatusMessageType.LOG);
                                             }
                                         }
                                     }
-                                } while ( (lastReadTime < keyByteTimeOut) || ((keyBytes.Count < 2) && (lastReadTime < lastChanceKeyByteTimeOut)) );
-
-                                DisplayStatusMessage("Slow init key byte read finished: count=" + keyBytes.Count
-                                    + ", elapsed=" + watch.ElapsedMilliseconds + " ms, raw=["
-                                    + FormatSlowInitHexDump(keyBytes.ToArray(), (uint)keyBytes.Count) + "].", StatusMessageType.LOG);
+                                } while ((keyBytes.Count < 2) && ((lastReadTime < keyByteTimeOut) || (lastReadTime < lastChanceKeyByteTimeOut)));
 
                                 //did we read enough key bytes?
                                 //todo: according to the spec there could be more than two key bytes
                                 if (keyBytes.Count >= 2)
                                 {
-                                    // Switch from slow-init data format (7E1) to 8N1 before sending key byte complement
+                                    // Begin critical timing (ISO 14230 W4): from here through Write,
+                                    // elapsed since last key byte must stay 25-50 ms. No logging in this block
+                                    // (issue #95 / #76 DisplayStatusMessage can exceed W4Max on a loaded host).
                                     success &= mCommunicationDevice.SetTimeouts(FTDIDeviceReadTimeOutMs, FTDIDeviceWriteTimeOutMs);
 
-                                    //send the complement of the last key byte
                                     byte[] keyByteComp = new byte[1];
                                     keyByteComp[0] = (byte)~keyBytes[keyBytes.Count - 1];
 
-                                    DisplayStatusMessage("Slow init sending key byte complement 0x"
-                                        + keyByteComp[0].ToString("X2") + " (W4Min wait "
-                                        + (uint)SlowInitConnectionTiming.W4Min + " ms).", StatusMessageType.LOG);
-
-                                    //don't reset timer after trying to read last key byte
                                     while (watch.ElapsedMilliseconds < (uint)SlowInitConnectionTiming.W4Min) ;//busy loop
 
                                     uint numBytesWritten = 0;
                                     success &= mCommunicationDevice.Write(keyByteComp, keyByteComp.Length, ref numBytesWritten, 2) && (numBytesWritten == keyByteComp.Length);
+                                    long msAtKeyByteComplementWrite = watch.ElapsedMilliseconds;
+                                    watch.Stop();
+                                    // End critical timing (W4 send). Logging below is after Write.
 
                                     if (success && EnableSlowInitTimingLog)
                                     {
@@ -1771,7 +1764,11 @@ namespace Communication
                                         LogSlowInitHandshakePhase("key byte complement sent");
                                     }
 
-                                    watch.Stop();
+                                    DisplayStatusMessage("Slow init sent key byte complement 0x"
+                                        + keyByteComp[0].ToString("X2") + " at "
+                                        + msAtKeyByteComplementWrite + " ms (W4 "
+                                        + (uint)SlowInitConnectionTiming.W4Min + "-"
+                                        + (uint)SlowInitConnectionTiming.W4Max + " ms).", StatusMessageType.LOG);
 
                                     if (success)
                                     {

--- a/Communication/KWP2000Interface.cs
+++ b/Communication/KWP2000Interface.cs
@@ -1770,6 +1770,13 @@ namespace Communication
                                         + (uint)SlowInitConnectionTiming.W4Min + "-"
                                         + (uint)SlowInitConnectionTiming.W4Max + " ms).", StatusMessageType.LOG);
 
+                                    if (EnableSlowInitTimingLog)
+                                    {
+                                        DisplayStatusMessage("Slow init key byte read finished: count=" + keyBytes.Count
+                                            + ", raw=["
+                                            + FormatSlowInitHexDump(keyBytes.ToArray(), (uint)keyBytes.Count) + "].", StatusMessageType.LOG);
+                                    }
+
                                     if (success)
                                     {
                                         if (mConsumeTransmitEcho)

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Open-source tool for reading, writing, and tuning VW/Audi ME7 ECUs via KWP2000
 
 - Slow init uses per-bit break timing (not a single low-baud UART frame). Validated on ME7.1 and ME7.5 bench with FTDI and CH340.
 - Clone or poor-quality adapters may fail slow init on either chip type; **Slow init timing log** helps compare timing.
-- In-car K-line (cluster) is not the same as bench. Some ME7.5 images (`06A906032HN`) connect on v1.9.4.3 but miss the KWP2000 address complement on v1.9.6.1+ — [issue #95](https://github.com/NefMoto/NefMotoOpenSource/issues/95).
+- In-car K-line (cluster) is not the same as bench. Some ME7.5 images (`06A906032HN`) connect on v1.9.4.3 but miss the KWP2000 address complement on v1.9.6.1+ in the car — [issue #95](https://github.com/NefMoto/NefMotoOpenSource/issues/95). Idle bench/laptop on the same image often still connects.
 
 ### Bootmode
 
@@ -62,7 +62,7 @@ Open-source tool for reading, writing, and tuning VW/Audi ME7 ECUs via KWP2000
 
 ### Known Issues
 
-- [Issue #95](https://github.com/NefMoto/NefMotoOpenSource/issues/95) — in-car slow init can miss the KWP2000 address complement on v1.9.6.1+ (v1.9.4.3 works). Bench direct K-line often still succeeds. Developer notes: [docs/KWP2000.md](docs/KWP2000.md).
+- [Issue #95](https://github.com/NefMoto/NefMotoOpenSource/issues/95) — in-car slow init can miss the KWP2000 address complement on v1.9.6.1+ (v1.9.4.3 works). ISO W4 is 25–50 ms; extra work before `0x70` plus a slow host can miss it. Idle bench/laptop often still succeeds. Developer notes: [docs/KWP2000.md](docs/KWP2000.md).
 - [Issue #100](https://github.com/NefMoto/NefMotoOpenSource/issues/100) — KWP write hang after ident (connect already up). Separate from #95.
 - Other issues: [GitHub Issues](https://github.com/NefMoto/NefMotoOpenSource/issues)
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Open-source tool for reading, writing, and tuning VW/Audi ME7 ECUs via KWP2000
 
 - Slow init uses per-bit break timing (not a single low-baud UART frame). Validated on ME7.1 and ME7.5 bench with FTDI and CH340.
 - Clone or poor-quality adapters may fail slow init on either chip type; **Slow init timing log** helps compare timing.
+- In-car K-line (cluster) is not the same as bench. Some ME7.5 images (`06A906032HN`) connect on v1.9.4.3 but miss the KWP2000 address complement on v1.9.6.1+ — [issue #95](https://github.com/NefMoto/NefMotoOpenSource/issues/95).
 
 ### Bootmode
 
@@ -61,7 +62,9 @@ Open-source tool for reading, writing, and tuning VW/Audi ME7 ECUs via KWP2000
 
 ### Known Issues
 
-See [GitHub Issues](https://github.com/NefMoto/NefMotoOpenSource/issues) for current known issues and feature requests.
+- [Issue #95](https://github.com/NefMoto/NefMotoOpenSource/issues/95) — in-car slow init can miss the KWP2000 address complement on v1.9.6.1+ (v1.9.4.3 works). Bench direct K-line often still succeeds. Developer notes: [docs/KWP2000.md](docs/KWP2000.md).
+- [Issue #100](https://github.com/NefMoto/NefMotoOpenSource/issues/100) — KWP write hang after ident (connect already up). Separate from #95.
+- Other issues: [GitHub Issues](https://github.com/NefMoto/NefMotoOpenSource/issues)
 
 ## Building
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Open-source tool for reading, writing, and tuning VW/Audi ME7 ECUs via KWP2000
 
 - Slow init uses per-bit break timing (not a single low-baud UART frame). Validated on ME7.1 and ME7.5 bench with FTDI and CH340.
 - Clone or poor-quality adapters may fail slow init on either chip type; **Slow init timing log** helps compare timing.
-- In-car K-line (cluster) is not the same as bench. Some ME7.5 images (`06A906032HN`) connect on v1.9.4.3 but miss the KWP2000 address complement on v1.9.6.1+ in the car — [issue #95](https://github.com/NefMoto/NefMotoOpenSource/issues/95). Idle bench/laptop on the same image often still connects.
+- In-car K-line (cluster) is not the same as bench.
 
 ### Bootmode
 
@@ -62,7 +62,7 @@ Open-source tool for reading, writing, and tuning VW/Audi ME7 ECUs via KWP2000
 
 ### Known Issues
 
-- [Issue #95](https://github.com/NefMoto/NefMotoOpenSource/issues/95) — in-car slow init can miss the KWP2000 address complement on v1.9.6.1+ (v1.9.4.3 works). ISO W4 is 25–50 ms; extra work before `0x70` plus a slow host can miss it. Idle bench/laptop often still succeeds. Developer notes: [docs/KWP2000.md](docs/KWP2000.md).
+- [Issue #95](https://github.com/NefMoto/NefMotoOpenSource/issues/95) — in-car slow init can miss the KWP2000 address complement.
 - [Issue #100](https://github.com/NefMoto/NefMotoOpenSource/issues/100) — KWP write hang after ident (connect already up). Separate from #95.
 - Other issues: [GitHub Issues](https://github.com/NefMoto/NefMotoOpenSource/issues)
 

--- a/docs/KWP2000.md
+++ b/docs/KWP2000.md
@@ -44,6 +44,8 @@ Slow init address **`0x01`**; fast init physical **`0x01`**.
 
 **Bench guidance:** use **slow init** @ **`0x01`**. ME7.5 fast init fails on this unit (not an adapter issue — slow init works on the same K-line). Other flash images may differ; no auto fallback in code.
 
+Direct K-line is not in-car (cluster). In-car complement miss: [issue #95](https://github.com/NefMoto/NefMotoOpenSource/issues/95).
+
 ---
 
 ## Connect UI
@@ -111,4 +113,5 @@ Legacy **`AllowCh340SlowInit`** is removed (ignored in old user.config). CH340 s
 
 - [README.md](../README.md)
 - [issue #76](https://github.com/NefMoto/NefMotoOpenSource/issues/76) — CH340 slow init
+- [issue #95](https://github.com/NefMoto/NefMotoOpenSource/issues/95) — in-car address complement miss
 - [issue #44](https://github.com/NefMoto/NefMotoOpenSource/issues/44) — CH340 bootmode baud

--- a/docs/KWP2000.md
+++ b/docs/KWP2000.md
@@ -46,6 +46,8 @@ Slow init address **`0x01`**; fast init physical **`0x01`**.
 
 Direct K-line is not in-car (cluster). In-car complement miss: [issue #95](https://github.com/NefMoto/NefMotoOpenSource/issues/95).
 
+ISO **W4** (25–50 ms after last key byte): tester must send `~key` (`0x70` here) in that window. [#76](https://github.com/NefMoto/NefMotoOpenSource/issues/76) logged before that `Write`. Field 1.9.6.1+ can `read=0` on the address complement; v1.9.4.3 connects. Idle laptop/bench on the same `0001` image often still gets `0xFE` even at key-byte `elapsed=48–49` ms. `SendSlowInit` sends `0x70` at W4Min before handshake logs.
+
 ---
 
 ## Connect UI

--- a/docs/KWP2000.md
+++ b/docs/KWP2000.md
@@ -44,9 +44,31 @@ Slow init address **`0x01`**; fast init physical **`0x01`**.
 
 **Bench guidance:** use **slow init** @ **`0x01`**. ME7.5 fast init fails on this unit (not an adapter issue — slow init works on the same K-line). Other flash images may differ; no auto fallback in code.
 
-Direct K-line is not in-car (cluster). In-car complement miss: [issue #95](https://github.com/NefMoto/NefMotoOpenSource/issues/95).
+Direct K-line is not in-car (cluster). In-car miss of the address complement: [issue #95](https://github.com/NefMoto/NefMotoOpenSource/issues/95).
 
-ISO **W4** (25–50 ms after last key byte): tester must send `~key` (`0x70` here) in that window. [#76](https://github.com/NefMoto/NefMotoOpenSource/issues/76) logged before that `Write`. Field 1.9.6.1+ can `read=0` on the address complement; v1.9.4.3 connects. Idle laptop/bench on the same `0001` image often still gets `0xFE` even at key-byte `elapsed=48–49` ms. `SendSlowInit` sends `0x70` at W4Min before handshake logs.
+---
+
+## Slow init timing (ISO 14230)
+
+Handshake uses **W0–W5**, not the session **P1–P4** timers. **P4** is tester inter-byte spacing after connect (default 5–20 ms). The critical handshake window is **W4**.
+
+| Timer | Window | Meaning |
+| --- | --- | --- |
+| W1 | 60–450 ms | After address, wait for ECU `0x55` |
+| W2 | 5–20 ms | Sync to first key byte |
+| W3 | 0–20 ms | Between key bytes |
+| **W4** | **25–50 ms** | After last key byte: tester sends `~key`; then ECU sends address complement |
+| W5 | ≥ 300 ms | Idle before retransmitting the address |
+
+**W4 is a hard window.** Extra work before `Write(~key)` (UI logs, waiting W3Max for a third key byte) can push past 50 ms. The ECU then sends nothing; the tester logs `success=True, read=0` on the address complement. Idle bench often still hits `0xFE`; a loaded host or in-car K-line through the cluster may not.
+
+`SendSlowInit` (`Communication/KWP2000Interface.cs`):
+
+- Stop the key-byte poll once two bytes are in
+- Wait **W4Min**, then `Write` — no `DisplayStatusMessage` in that interval
+- Read the address complement with a 100 ms timeout (W4Max + USB margin)
+
+Typical ME7 keys `EF 8F` → tester `0x70` → complement `0xFE` (or `0xEE` if 7-bit).
 
 ---
 
@@ -114,6 +136,6 @@ Legacy **`AllowCh340SlowInit`** is removed (ignored in old user.config). CH340 s
 ## References
 
 - [README.md](../README.md)
+- [issue #44](https://github.com/NefMoto/NefMotoOpenSource/issues/44) — CH340 bootmode baud
 - [issue #76](https://github.com/NefMoto/NefMotoOpenSource/issues/76) — CH340 slow init
 - [issue #95](https://github.com/NefMoto/NefMotoOpenSource/issues/95) — in-car address complement miss
-- [issue #44](https://github.com/NefMoto/NefMotoOpenSource/issues/44) — CH340 bootmode baud


### PR DESCRIPTION
v1.9.4.3 completed in-car slow init on 06A906032HN; v1.9.6.1+ died on the KWP2000 address-complement byte. #76 added SetDataCharacteristics(8N1) immediately before that read. The UART is already 8N1 from connect.

Remove that call (same as 1.9.4.3). Keep the 100 ms complement timeout. Log the 0x70 echo for field logs

Send key complement at W4Min before logs

ISO 14230 W4 requires ~last-key (0x70) 25-50 ms after the last key byte. #76 logged and kept polling for a third key in that window; on a loaded host that can exceed W4Max so the ECU never sends 0xFE.

After two key bytes, wait W4Min then Write with no DisplayStatusMessage in between. Log send time after Write.

Fixes #95