### PR TITLE
Issue #104: Sleep+spin instead of busy-wait on slack timers

### DIFF
--- a/Communication/KWP2000Interface.cs
+++ b/Communication/KWP2000Interface.cs
@@ -1154,6 +1154,7 @@ namespace Communication
         private const uint SLOW_INIT_ADDRESS_COMPLEMENT_READ_TIMEOUT_MS = 100;//W4Max 50 ms + margin for USB serial (CH340)
         private const uint DUMB_ADAPTER_ECHO_READ_TIMEOUT_MS = 100;
         private const uint SLOW_INIT_TX_DRAIN_TIMEOUT_MS = 500;
+        private const int SleepOverheadMs = 16;//Windows timer tick ~15.6 ms; Sleep this much short of target, then spin
 
         protected enum SlowInitParity
         {
@@ -1295,6 +1296,7 @@ namespace Communication
                 Stopwatch watch = new Stopwatch();
                 watch.Start();
                 long previousBitEndMs = 0;
+                long maxOvershootMs = 0;
                 void LogSlowInitBitPeriod(string bitLabel, bool lineLow, bool setBreakToggled)
                 {
                     if (!EnableSlowInitTimingLog)
@@ -1311,12 +1313,21 @@ namespace Communication
                         + ", elapsed=" + elapsedMs + " ms, period=" + periodMs + " ms.", StatusMessageType.DEV);
                 }
 
+                void WaitBit(long endTicks)
+                {
+                    long os = WaitUntilElapsedTicks(watch, endTicks);
+                    if (os > maxOvershootMs)
+                    {
+                        maxOvershootMs = os;
+                    }
+                }
+
                 //low start bit
                 success = mCommunicationDevice.SetBreak(true);//low
                 bool isLow = true;
 
                 long currentBitEndTime = FIVE_BAUD_BIT_TIME_TICKS;
-                while (watch.ElapsedTicks < currentBitEndTime) ;//busy loop
+                WaitBit(currentBitEndTime);
                 LogSlowInitBitPeriod("start", isLow, true);
 
                 int numHighBits = 0;
@@ -1351,7 +1362,7 @@ namespace Communication
                     }
 
                     currentBitEndTime += FIVE_BAUD_BIT_TIME_TICKS;
-                    while (watch.ElapsedTicks < currentBitEndTime) ;//busy loop
+                    WaitBit(currentBitEndTime);
                     LogSlowInitBitPeriod("D" + y + "=" + (isHighBit ? "1" : "0"), isLow, setBreakToggled);
                 }
 
@@ -1382,7 +1393,7 @@ namespace Communication
                     }
 
                     currentBitEndTime += FIVE_BAUD_BIT_TIME_TICKS;
-                    while (watch.ElapsedTicks < currentBitEndTime) ;//busy loop
+                    WaitBit(currentBitEndTime);
                     LogSlowInitBitPeriod("parity", isLow, setBreakToggled);
                 }
 
@@ -1417,6 +1428,9 @@ namespace Communication
                 {
                     DisplayStatusMessage("Failed to send five baud slow init address.", StatusMessageType.LOG);
                 }
+
+                long expectedBitMs = FIVE_BAUD_BIT_TIME_TICKS * 1000 / Stopwatch.Frequency;
+                LogWaitUntilOvershoot("five-baud", expectedBitMs, maxOvershootMs);
             }
 
             return success;
@@ -1513,11 +1527,13 @@ namespace Communication
                         continue;
                     }
 
-                    while (watch.ElapsedMilliseconds < frameTimeMs) ;//busy wait for full frame on wire
+                    long overshootMs = WaitUntilElapsedMs(watch, frameTimeMs);
 
                     success &= WaitForDeviceTransmitDrain(SLOW_INIT_TX_DRAIN_TIMEOUT_MS);
                     success &= mCommunicationDevice.SetBaudRate(DEFAULT_COMMUNICATION_BAUD_RATE);
                     success &= mCommunicationDevice.SetDataCharacteristics(DataBits.Bits8, StopBits.Bits1, Parity.None);
+
+                    LogWaitUntilOvershoot("ch340-frame", frameTimeMs, overshootMs);
 
                     if (success)
                     {
@@ -2398,13 +2414,12 @@ namespace Communication
 
             if (result)
             {
-                {
-                    Stopwatch stopwatch = new Stopwatch();
-                    stopwatch.Start();
-                    while (stopwatch.ElapsedMilliseconds < KWP1281_TesterMinTimeToSendResponseMessageMS) ;//busy loop
-                }
+                Stopwatch stopwatch = new Stopwatch();
+                stopwatch.Start();
+                long overshootMs = WaitUntilElapsedMs(stopwatch, KWP1281_TesterMinTimeToSendResponseMessageMS);
 
                 result = KWP1281SendAckBlock(messageBlock);
+                LogWaitUntilOvershoot("kwp1281-ack", KWP1281_TesterMinTimeToSendResponseMessageMS, overshootMs);
             }
 
             return result;
@@ -2429,11 +2444,9 @@ namespace Communication
 
                 if (sendOK)
                 {
-                    {
-                        Stopwatch stopwatch = new Stopwatch();
-                        stopwatch.Start();
-                        while (stopwatch.ElapsedMilliseconds < KWP1281_TesterMinTimeToSendResponseMessageMS) ;//busy loop
-                    }
+                    Stopwatch stopwatch = new Stopwatch();
+                    stopwatch.Start();
+                    long overshootMs = WaitUntilElapsedMs(stopwatch, KWP1281_TesterMinTimeToSendResponseMessageMS);
 
                     lastBlockCounter = messageBlock.mBlockCounter;
 
@@ -2460,12 +2473,18 @@ namespace Communication
                         if (sendOK)
                         {
                             lastBlockCounter++;
-                            break;
                         }
                         else
                         {
                             DisplayStatusMessage("Failed to send end block", StatusMessageType.DEV);
                         }
+                    }
+
+                    LogWaitUntilOvershoot("kwp1281-ack", KWP1281_TesterMinTimeToSendResponseMessageMS, overshootMs);
+
+                    if ((messageBlock.mBlockTitle == (byte)KWP1281BlockTitle.Acknowledge) && sendOK)
+                    {
+                        break;
                     }
 
                     //check for ASCII block
@@ -2492,6 +2511,59 @@ namespace Communication
             success &= mCommunicationDevice.SetTimeouts(FTDIDeviceReadTimeOutMs, FTDIDeviceWriteTimeOutMs);
 
             return sendOK;
+        }
+
+        // Sleep (target - SleepOverheadMs) then spin to target. Returns overshoot ms. Does not log.
+        private static long WaitUntilElapsedMs(Stopwatch watch, long targetMs)
+        {
+            long remaining = targetMs - watch.ElapsedMilliseconds;
+            if (remaining > SleepOverheadMs)
+            {
+                Thread.Sleep((int)(remaining - SleepOverheadMs));
+            }
+
+            while (watch.ElapsedMilliseconds < targetMs)
+            {
+                ;
+            }
+
+            return watch.ElapsedMilliseconds - targetMs;
+        }
+
+        // Sleep (target - SleepOverheadMs) then spin to the tick deadline. Returns overshoot ms. Does not log.
+        private static long WaitUntilElapsedTicks(Stopwatch watch, long targetTicks)
+        {
+            long remainingTicks = targetTicks - watch.ElapsedTicks;
+            if (remainingTicks > 0)
+            {
+                long remainingMs = remainingTicks * 1000 / Stopwatch.Frequency;
+                if (remainingMs > SleepOverheadMs)
+                {
+                    Thread.Sleep((int)(remainingMs - SleepOverheadMs));
+                }
+            }
+
+            while (watch.ElapsedTicks < targetTicks)
+            {
+                ;
+            }
+
+            long overshootTicks = watch.ElapsedTicks - targetTicks;
+            if (overshootTicks <= 0)
+            {
+                return 0;
+            }
+
+            return overshootTicks * 1000 / Stopwatch.Frequency;
+        }
+
+        void LogWaitUntilOvershoot(string label, long expectedMs, long overshootMs)
+        {
+            if (overshootMs > 0)
+            {
+                DisplayStatusMessage("WaitUntil " + label + ": expected=" + expectedMs
+                    + " ms overshoot=" + overshootMs + " ms.", StatusMessageType.LOG);
+            }
         }
 
         protected bool Connect_SlowInit()
@@ -2531,12 +2603,11 @@ namespace Communication
                 //wait for the required idle time
                 Stopwatch watch = new Stopwatch(); watch.Start();
                 const uint idleTime = 2600;//VW says they need a min of 2.6 seconds between slow inits//(uint)SlowInitConnectionTiming.W0Min + (uint)SlowInitConnectionTiming.W5Min;
-                Thread.Sleep((int)idleTime);
-                while (watch.ElapsedMilliseconds < idleTime) ;//busy wait
-                watch.Stop();
+                long overshootMs = WaitUntilElapsedMs(watch, idleTime);
 
                 DisplayStatusMessage("Connecting to address 0x" + mConnectAddress.ToString("X2") + ".", StatusMessageType.USER);
                 slowInitSuccess = SendSlowInit(mConnectAddress, SlowInitDataBits.Seven, SlowInitParity.Odd, out keyByte1, out keyByte2);
+                LogWaitUntilOvershoot("slow-init-idle", idleTime, overshootMs);
 
                 if (slowInitSuccess)
                 {
@@ -2552,12 +2623,11 @@ namespace Communication
 
                         //wait additional time to give the ECU time to switch to KWP2000
                         watch.Reset(); watch.Start();
-                        while (watch.ElapsedMilliseconds < TimeBetweenSlowInitForKWP2000MS) ;
+                        overshootMs = WaitUntilElapsedMs(watch, TimeBetweenSlowInitForKWP2000MS);
 
-                        DisplayStatusMessage("Slow init: second attempt after KWP1281, waiting "
-                            + TimeBetweenSlowInitForKWP2000MS + " ms.", StatusMessageType.LOG);
                         DisplayStatusMessage("Connecting to address 0x" + mConnectAddress.ToString("X2") + ".", StatusMessageType.USER);
                         slowInitSuccess = SendSlowInit(mConnectAddress, SlowInitDataBits.Seven, SlowInitParity.Odd, out keyByte1, out keyByte2);
+                        LogWaitUntilOvershoot("kwp1281-gap", TimeBetweenSlowInitForKWP2000MS, overshootMs);
 
                         if (slowInitSuccess)
                         {
@@ -2589,12 +2659,13 @@ namespace Communication
 
                         //wait additional time to give the ECU time to switch to KWP2000
                         watch.Reset(); watch.Start();
-                        while (watch.ElapsedMilliseconds < TimeBetweenSlowInitForKWP2000MS) ;
+                        overshootMs = WaitUntilElapsedMs(watch, TimeBetweenSlowInitForKWP2000MS);
 
                         //we don't set the mConnectAddress here because we are overriding it and don't want to set it
                         connectAddressOverride = DEFAULT_ECU_SLOWINIT_KWP2000_ADDRESS;
                         DisplayStatusMessage("Connecting to address 0x" + connectAddressOverride.ToString("X2") + ".", StatusMessageType.USER);
                         slowInitSuccess = SendSlowInit(connectAddressOverride, SlowInitDataBits.Seven, SlowInitParity.Even, out keyByte1, out keyByte2);
+                        LogWaitUntilOvershoot("kwp1281-gap-0x11", TimeBetweenSlowInitForKWP2000MS, overshootMs);
 
                         if (slowInitSuccess)
                         {
@@ -2627,9 +2698,10 @@ namespace Communication
                                 var startCommMessage = new KWP2000Message(mConnectAddressMode, TESTER_ADDRESS, mConnectAddress, KWP2000ServiceID.StartCommunication, 0, null);
                                 SendMessage(startCommMessage);//queue the message, so we know to expect a response
 
-                                while (watch.ElapsedMilliseconds < TimeAfterSlowInitBeforeStartCommMessageMS) ;//busy loop, give the ecu time to get ready to receive the message, Galletto waits 280ms
+                                overshootMs = WaitUntilElapsedMs(watch, TimeAfterSlowInitBeforeStartCommMessageMS);//Galletto waits 280ms
 
                                 slowInitSuccess = TransmitMessage(startCommMessage, false, 0);
+                                LogWaitUntilOvershoot("startcomm", TimeAfterSlowInitBeforeStartCommMessageMS, overshootMs);
 
                                 if (slowInitSuccess)
                                 {
@@ -3041,9 +3113,7 @@ connectEndTime = connectStartTime + connectTime + 3;
                     if (mCommunicationDevice.SetBreak(false))//let the line return to normal high state
                     {
                         watch.Start();
-                        long idleEndTime = watch.ElapsedMilliseconds + idleTimeMS;
-                        Thread.Sleep((int)idleTimeMS);//OK to sleep because we don't care if we wait for too long
-                        while (watch.ElapsedMilliseconds < idleEndTime) ;
+                        long overshootMs = WaitUntilElapsedMs(watch, idleTimeMS);
 
                         //timing is more accurate when done before setting break
                         //lowEndTime = watch.ElapsedMilliseconds + lowTime + offset;
@@ -3080,6 +3150,8 @@ connectEndTime = connectStartTime + connectTime + 3;
                         {
                             DisplayStatusMessage("Failed to set break on device.", StatusMessageType.LOG);
                         }
+
+                        LogWaitUntilOvershoot("fast-init-idle", idleTimeMS, overshootMs);
                     }
                     else
                     {

--- a/Installer/Product.wxs
+++ b/Installer/Product.wxs
@@ -15,14 +15,16 @@
   <?define FullVersion=$(env.FULL_VERSION)?>
   <?define TargetDir=$(env.ECUFlasher_TargetDir)?>
   <?define MemoryLayouts_TargetDir=MemoryLayouts\?>
-  <Package Id="NefMotoECUFlasher"
+  <!-- No Package Id: new ProductCode each build (required for x86→x64; Keep UpgradeCode). -->
+  <Package
     Name="$(var.ProductName) $(var.FullVersion)"
     Language="1033"
     Version="!(bind.fileVersion.$(var.ProductName).exe)"
     Manufacturer="Nefmoto"
     UpgradeCode="2d104af1-44d2-4686-b3e0-a860cb092af1"
     InstallerVersion="500"
-    Compressed="yes">
+    Compressed="yes"
+    Scope="perMachine">
     <MediaTemplate EmbedCab="yes" />
 
     <Feature Id="ProductFeature" Title="$(var.ProductName)" Level="1">
@@ -42,18 +44,16 @@
     <ui:WixUI Id="WixUI_InstallDir" />
     <Property Id="WIXUI_EXITDIALOGOPTIONALCHECKBOX" Value="0" />
 
-    <!-- MajorUpgrade configuration: Handles upgrades and downgrades (must be in Package element) -->
+    <!-- AllowDowngrades also removes same-version products (conflicts with AllowSameVersionUpgrades). -->
     <MajorUpgrade
       AllowDowngrades="yes"
       Schedule="afterInstallInitialize" />
 
     <!-- Desktop runtime check. Interactive UI uses a Hyperlink dialog; LaunchCondition covers silent /qn. -->
     <Property Id="DOTNETDESKTOPSTATUS" Secure="yes" />
-    <Property Id="DOTNETDESKTOPSTATUS86" Secure="yes" />
     <netfx:DotNetCompatibilityCheckRef Id="NetDesktopCheckX64" />
-    <netfx:DotNetCompatibilityCheckRef Id="NetDesktopCheckX86" />
     <Launch
-      Condition="Installed OR DOTNETDESKTOPSTATUS=&quot;0&quot; OR DOTNETDESKTOPSTATUS86=&quot;0&quot;"
+      Condition="Installed OR DOTNETDESKTOPSTATUS=&quot;0&quot;"
       Message="This application requires the .NET $(var.DotNetMajor) Desktop Runtime (x64). Please install it from $(var.DotNetDesktopRuntimeUrl)" />
 
     <UI>
@@ -70,23 +70,29 @@
         </Control>
       </Dialog>
       <InstallUISequence>
-        <!-- Must run after Wix4NetFxDotNetCompatibilityCheck_X86 (seq 99). Before=LaunchConditions
-             was seq 98, so empty properties matched <> "0" and always showed this dialog. -->
-        <Show Dialog="NetFxRequiredDlg" After="Wix4NetFxDotNetCompatibilityCheck_X86"
-          Condition="NOT Installed AND DOTNETDESKTOPSTATUS AND DOTNETDESKTOPSTATUS86 AND DOTNETDESKTOPSTATUS &lt;&gt; &quot;0&quot; AND DOTNETDESKTOPSTATUS86 &lt;&gt; &quot;0&quot;" />
+        <!-- Must run after Wix4NetFxDotNetCompatibilityCheck_X64. Before=LaunchConditions
+             was seq 98, so an empty property matched <> "0" and always showed this dialog. -->
+        <Show Dialog="NetFxRequiredDlg" After="Wix4NetFxDotNetCompatibilityCheck_X64"
+          Condition="NOT Installed AND DOTNETDESKTOPSTATUS AND DOTNETDESKTOPSTATUS &lt;&gt; &quot;0&quot;" />
       </InstallUISequence>
     </UI>
 
     <!-- Remove shortcuts on uninstall (custom action; WiX component removal fails for per-user paths) -->
     <CustomAction Id="RemoveShortcutsCA" Directory="System6432Folder" ExeCommand="cmd.exe /c del /q &quot;%PUBLIC%\Desktop\NefMotoECUFlasher.lnk&quot; 2&gt;nul &amp; del /q &quot;%USERPROFILE%\Desktop\NefMotoECUFlasher.lnk&quot; 2&gt;nul &amp; rmdir /s /q &quot;%ProgramData%\Microsoft\Windows\Start Menu\Programs\NefMotoECUFlasher&quot; 2&gt;nul &amp; rmdir /s /q &quot;%APPDATA%\Microsoft\Windows\Start Menu\Programs\NefMotoECUFlasher&quot; 2&gt;nul" Return="ignore" />
+    <!-- x86 leftover: FRP only sees products in the Installer DB. 1.9.5.1 on this machine had ARP+files but no Products key.
+         Nested msiexec /x is illegal during this install. Always clear the default x86 dir + known x86 ARP GUID
+         (WiX v4 Package Id=NefMotoECUFlasher → {88620197-DC15-4265-9F10-8715C6347BE1}). -->
+    <CustomAction Id="RemoveOldX86Install" Directory="System64Folder" Execute="deferred" Impersonate="no" Return="ignore"
+      ExeCommand="cmd.exe /c if exist &quot;[ProgramFilesFolder]NefMotoECUFlasher&quot; rmdir /s /q &quot;[ProgramFilesFolder]NefMotoECUFlasher&quot; &amp; reg delete &quot;HKLM\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\{88620197-DC15-4265-9F10-8715C6347BE1}&quot; /f 2&gt;nul &amp; reg delete &quot;HKLM\SOFTWARE\WOW6432Node\Nefmoto\NefMotoECUFlasher&quot; /f 2&gt;nul" />
     <InstallExecuteSequence>
+      <Custom Action="RemoveOldX86Install" After="InstallFiles" Condition="NOT REMOVE~=&quot;ALL&quot;" />
       <Custom Action="RemoveShortcutsCA" Before="RemoveFiles" Condition="REMOVE~=&quot;ALL&quot;" />
     </InstallExecuteSequence>
   </Package>
 
   <Fragment>
     <ComponentGroup Id="ApplicationShortcuts" Directory="ApplicationProgramsFolder">
-      <Component Id="ApplicationProgramsFolder" Guid="a1b2c3d4-e5f6-7890-abcd-ef1234567890">
+      <Component Id="ApplicationProgramsFolder" Guid="*">
         <RemoveFolder Id="RemoveApplicationProgramsFolder" Directory="ApplicationProgramsFolder" On="uninstall" />
         <RegistryValue Root="HKMU" Key="Software\Nefmoto\$(var.ProductName)" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
       </Component>
@@ -100,14 +106,6 @@
       RuntimeType="desktop"
       Version="$(var.DotNetMajor).0.0"
       Platform="x64"
-      RollForward="latestMajor" />
-
-    <netfx:DotNetCompatibilityCheck
-      Id="NetDesktopCheckX86"
-      Property="DOTNETDESKTOPSTATUS86"
-      RuntimeType="desktop"
-      Version="$(var.DotNetMajor).0.0"
-      Platform="x86"
       RollForward="latestMajor" />
   </Fragment>
 
@@ -134,7 +132,7 @@
   <Fragment>
     <!-- Desktop shortcut component -->
     <ComponentGroup Id="DesktopShortcut" Directory="DesktopFolder">
-      <Component Id="DesktopShortcutComponent" Guid="f1e2d3c4-b5a6-9780-cdef-123456789abc">
+      <Component Id="DesktopShortcutComponent" Guid="*">
         <Shortcut Id="DesktopShortcut" Name="$(var.ProductName)" Target="[INSTALLFOLDER]$(var.ProductName).exe" WorkingDirectory="INSTALLFOLDER" Icon="AppIcon" />
         <RegistryValue Root="HKMU" Key="Software\Nefmoto\$(var.ProductName)" Name="DesktopShortcut" Type="integer" Value="1" KeyPath="yes" />
       </Component>
@@ -145,7 +143,7 @@
   <Fragment>
     <Icon Id="AppIcon" SourceFile="$(var.TargetDir)$(var.ProductName).exe" />
     <ComponentGroup Id="ProductComponents" Directory="INSTALLFOLDER">
-      <Component Id="$(var.ProductName).exe" Guid="d2e4f421-0c73-4562-9af9-4f10dd16f278">
+      <Component Id="$(var.ProductName).exe" Guid="*">
         <File Id="$(var.ProductName).exe" Name="$(var.ProductName).exe" Source="$(var.TargetDir)$(var.ProductName).exe" KeyPath="yes">
           <Shortcut Id="StartMenuShortcut" Directory="ApplicationProgramsFolder" Name="$(var.ProductName)" WorkingDirectory="INSTALLFOLDER" Icon="AppIcon" />
         </File>
@@ -153,51 +151,63 @@
         <RemoveFile Id="RemoveDesktopShortcut" Name="$(var.ProductName).lnk" Directory="DesktopFolder" On="uninstall" />
         <RemoveFile Id="RemoveCommonDesktopShortcut" Name="$(var.ProductName).lnk" Property="CommonDesktopFolder" On="uninstall" />
       </Component>
-      <Component Id="$(var.ProductName).exe.config" Guid="5d029180-2042-4344-b43b-e5b0809e9887">
+      <Component Id="$(var.ProductName).exe.config" Guid="*">
         <File Id="$(var.ProductName).exe.config" Name="$(var.ProductName).exe.config" Source="ECUFlasher\app.config" KeyPath="yes" />
       </Component>
-      <Component Id="$(var.ProductName).dll" Guid="1a2b3c4d-5e6f-7890-abcd-ef1234567890">
+      <Component Id="$(var.ProductName).dll" Guid="*">
         <File Id="$(var.ProductName).dll" Name="$(var.ProductName).dll" Source="$(var.TargetDir)$(var.ProductName).dll" KeyPath="yes" />
       </Component>
-      <Component Id="$(var.ProductName).runtimeconfig.json" Guid="b3c4d5e6-f7a8-9012-bcde-f12345678901">
+      <Component Id="$(var.ProductName).runtimeconfig.json" Guid="*">
         <File Id="$(var.ProductName).runtimeconfig.json" Name="$(var.ProductName).runtimeconfig.json" Source="$(var.TargetDir)NefMotoECUFlasher.runtimeconfig.json" KeyPath="yes" />
       </Component>
-      <Component Id="$(var.ProductName).deps.json" Guid="c4d5e6f7-a8b9-0123-cdef-123456789012">
+      <Component Id="$(var.ProductName).deps.json" Guid="*">
         <File Id="$(var.ProductName).deps.json" Name="$(var.ProductName).deps.json" Source="$(var.TargetDir)NefMotoECUFlasher.deps.json" KeyPath="yes" />
       </Component>
-      <Component Id="FTD2XX_NET.dll" Guid="21949804-55a9-4cf1-b856-ce5b72fd3f6d">
+      <Component Id="FTD2XX_NET.dll" Guid="*">
         <File Id="FTD2XX_NET.dll" Name="FTD2XX_NET.dll" Source="$(var.TargetDir)FTD2XX_NET.dll" KeyPath="yes" />
       </Component>
-      <Component Id="Communication.dll" Guid="d4cf033c-6330-4e20-9130-f26ef46bbcc9">
+      <Component Id="Communication.dll" Guid="*">
         <File Id="Communication.dll" Name="Communication.dll" Source="$(var.TargetDir)Communication.dll" KeyPath="yes" />
       </Component>
-      <Component Id="ECUShared.dll" Guid="1161e03f-3326-4297-b492-1d333630dbae">
+      <Component Id="ECUShared.dll" Guid="*">
         <File Id="ECUShared.dll" Name="ECUShared.dll" Source="$(var.TargetDir)ECUShared.dll" KeyPath="yes" />
       </Component>
-      <Component Id="ApplicationShared.dll" Guid="d42fabc7-0a7b-48b2-8104-3b8f85d8d525">
+      <Component Id="ApplicationShared.dll" Guid="*">
         <File Id="ApplicationShared.dll" Name="ApplicationShared.dll" Source="$(var.TargetDir)ApplicationShared.dll" KeyPath="yes" />
       </Component>
-      <Component Id="Checksum.dll" Guid="e5f6a7b8-c9d0-e1f2-3456-789012345678">
+      <Component Id="Checksum.dll" Guid="*">
         <File Id="Checksum.dll" Name="Checksum.dll" Source="$(var.TargetDir)Checksum.dll" KeyPath="yes" />
       </Component>
     </ComponentGroup>
     <ComponentGroup Id="RuntimeDlls" Directory="RuntimeTfmFolder">
-      <Component Id="System.IO.Ports.dll.runtime" Guid="a7b8c9d0-e1f2-3456-7890-123456789abc">
+      <Component Id="System.IO.Ports.dll.runtime" Guid="*">
         <File Id="System.IO.Ports.dll.runtime" Name="System.IO.Ports.dll" Source="$(var.TargetDir)runtimes/win/lib/$(var.RuntimeTfm)/System.IO.Ports.dll" KeyPath="yes" />
       </Component>
-      <Component Id="System.Management.dll.runtime" Guid="b8c9d0e1-f2a3-4567-8901-23456789abcd">
+      <Component Id="System.Management.dll.runtime" Guid="*">
         <File Id="System.Management.dll.runtime" Name="System.Management.dll" Source="$(var.TargetDir)runtimes/win/lib/$(var.RuntimeTfm)/System.Management.dll" KeyPath="yes" />
       </Component>
     </ComponentGroup>
     <ComponentGroup Id="MemoryLayouts" Directory="MemoryLayoutsFolder">
-      <Component Id="MemoryLayoutFiles" Guid="68F489B1-19DD-4A65-9018-358BBCD9F342">
-        <File Id="ME7_29F200.MemoryLayout.xml" Name="ME7 29F200.MemoryLayout.xml" Source="$(var.MemoryLayouts_TargetDir)ME7 29F200.MemoryLayout.xml" />
-        <File Id="ME7_29F200BB.MemoryLayout.xml" Name="ME7 29F200BB.MemoryLayout.xml" Source="$(var.MemoryLayouts_TargetDir)ME7 29F200BB.MemoryLayout.xml" />
-        <File Id="ME7_29F400.MemoryLayout.xml" Name="ME7 29F400.MemoryLayout.xml" Source="$(var.MemoryLayouts_TargetDir)ME7 29F400.MemoryLayout.xml" />
-        <File Id="ME7_29F400BB.MemoryLayout.xml" Name="ME7 29F400BB.MemoryLayout.xml" Source="$(var.MemoryLayouts_TargetDir)ME7 29F400BB.MemoryLayout.xml" />
-        <File Id="ME7_29F800.MemoryLayout.xml" Name="ME7 29F800.MemoryLayout.xml" Source="$(var.MemoryLayouts_TargetDir)ME7 29F800.MemoryLayout.xml" />
-        <File Id="ME7_29F800BB.MemoryLayout.xml" Name="ME7 29F800BB.MemoryLayout.xml" Source="$(var.MemoryLayouts_TargetDir)ME7 29F800BB.MemoryLayout.xml" />
-        <File Id="ME7_29F800BT.MemoryLayout.xml" Name="ME7 29F800BT.MemoryLayout.xml" Source="$(var.MemoryLayouts_TargetDir)ME7 29F800BT.MemoryLayout.xml" />
+      <Component Id="ME7_29F200.MemoryLayout.xml" Guid="*">
+        <File Id="ME7_29F200.MemoryLayout.xml" Name="ME7 29F200.MemoryLayout.xml" Source="$(var.MemoryLayouts_TargetDir)ME7 29F200.MemoryLayout.xml" KeyPath="yes" />
+      </Component>
+      <Component Id="ME7_29F200BB.MemoryLayout.xml" Guid="*">
+        <File Id="ME7_29F200BB.MemoryLayout.xml" Name="ME7 29F200BB.MemoryLayout.xml" Source="$(var.MemoryLayouts_TargetDir)ME7 29F200BB.MemoryLayout.xml" KeyPath="yes" />
+      </Component>
+      <Component Id="ME7_29F400.MemoryLayout.xml" Guid="*">
+        <File Id="ME7_29F400.MemoryLayout.xml" Name="ME7 29F400.MemoryLayout.xml" Source="$(var.MemoryLayouts_TargetDir)ME7 29F400.MemoryLayout.xml" KeyPath="yes" />
+      </Component>
+      <Component Id="ME7_29F400BB.MemoryLayout.xml" Guid="*">
+        <File Id="ME7_29F400BB.MemoryLayout.xml" Name="ME7 29F400BB.MemoryLayout.xml" Source="$(var.MemoryLayouts_TargetDir)ME7 29F400BB.MemoryLayout.xml" KeyPath="yes" />
+      </Component>
+      <Component Id="ME7_29F800.MemoryLayout.xml" Guid="*">
+        <File Id="ME7_29F800.MemoryLayout.xml" Name="ME7 29F800.MemoryLayout.xml" Source="$(var.MemoryLayouts_TargetDir)ME7 29F800.MemoryLayout.xml" KeyPath="yes" />
+      </Component>
+      <Component Id="ME7_29F800BB.MemoryLayout.xml" Guid="*">
+        <File Id="ME7_29F800BB.MemoryLayout.xml" Name="ME7 29F800BB.MemoryLayout.xml" Source="$(var.MemoryLayouts_TargetDir)ME7 29F800BB.MemoryLayout.xml" KeyPath="yes" />
+      </Component>
+      <Component Id="ME7_29F800BT.MemoryLayout.xml" Guid="*">
+        <File Id="ME7_29F800BT.MemoryLayout.xml" Name="ME7 29F800BT.MemoryLayout.xml" Source="$(var.MemoryLayouts_TargetDir)ME7 29F800BT.MemoryLayout.xml" KeyPath="yes" />
       </Component>
     </ComponentGroup>
   </Fragment>

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ installer $(INSTALLER): $(RELEASE_DIR)/NefMotoECUFlasher.exe Installer/Product.w
 	@echo "Building $(INSTALLER) ($(FULL_VERSION), $(NET_TFM))..."
 	@mkdir -p Installer/bin/Release
 	@ECUFlasher_TargetDir="$(RELEASE_DIR)/" \
-	FULL_VERSION=$(FULL_VERSION) wix build -arch x86 \
+	FULL_VERSION=$(FULL_VERSION) wix build -arch x64 \
 		-d RuntimeTfm=$(NET_TFM) -d DotNetMajor=$(DOTNET_MAJOR) \
 		-ext WixToolset.UI.wixext -ext WixToolset.NetFx.wixext \
 		-o $(INSTALLER) Installer/Product.wxs

--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ See [RELEASE.md](docs/RELEASE.md) for release instructions.
 
 Pre-built releases are available at: <https://github.com/NefMoto/NefMotoOpenSource/releases/latest>
 
+The MSI is 64-bit and installs to `C:\Program Files\NefMotoECUFlasher`. Upgrading from an older x86 install should replace the copy under Program Files (x86).
+
 ## Requirements
 
 - Windows operating system

--- a/build.bat
+++ b/build.bat
@@ -42,7 +42,7 @@ REM If installer argument provided, build installer
 if "%1"=="installer" (
     set ECUFlasher_TargetDir=ECUFlasher/bin/msil/Release/
     echo Building installer/bin/Release/NefMotoECUFlasher-%FULL_VERSION%.msi...
-    wix build -arch x86 -d RuntimeTfm=%NET_TFM% -d DotNetMajor=%DOTNET_MAJOR% -ext WixToolset.UI.wixext -ext WixToolset.NetFx.wixext -o Installer/bin/Release/NefMotoECUFlasher-%FULL_VERSION%.msi Installer/Product.wxs
+    wix build -arch x64 -d RuntimeTfm=%NET_TFM% -d DotNetMajor=%DOTNET_MAJOR% -ext WixToolset.UI.wixext -ext WixToolset.NetFx.wixext -o Installer/bin/Release/NefMotoECUFlasher-%FULL_VERSION%.msi Installer/Product.wxs
     if errorlevel 1 exit /b %ERRORLEVEL%
 )
 

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -43,7 +43,7 @@ build.bat publish
 
 - **.NET 10 SDK** (preferred) or **Visual Studio** with MSBuild. End users of the MSI need the **.NET 10 Desktop Runtime**, not only the console runtime.
 - Target framework is `NetTfm` in [`Directory.Build.props`](../Directory.Build.props). Output dirs do not include the TFM (`ECUFlasher/bin/msil/Debug` / `Release`).
-- **WiX Toolset v6.0+** (for installer builds)
+- **WiX Toolset v6.0+** (for installer builds; MSI is **x64**, `-arch x64`)
   - `dotnet tool install --global wix --version 6.0.2`
 - **WiX UI and NetFX extensions**
   - `wix extension add WixToolset.UI.wixext WixToolset.NetFx.wixext --global`

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -58,7 +58,7 @@ To rebuild an existing tag without moving it, use **Actions → Release → Run 
 
 `build.yml` retains MSI workflow artifacts for 90 days; `release.yml` is what publishes the installer on GitHub Releases.
 
-The generated **Downloads** section includes a .NET 10 Desktop Runtime requirement (and a note that .NET 8 Desktop is not enough). Keep that in sync with README **Requirements**.
+The generated **Downloads** section includes a .NET 10 Desktop Runtime (x64) requirement (and a note that .NET 8 Desktop is not enough). Keep that in sync with README **Requirements**. The MSI is **x64** and installs to Program Files; upgrading from an older x86 MSI should uninstall the Program Files (x86) copy.
 
 ### What `release.yml` does
 


### PR DESCRIPTION
Replace Stopwatch busy loops with Sleep(T−16 ms) then spin to the deadline.

Converted:
- 2600 ms idle before slow/fast init
- 1500 ms after KWP1281 before the next slow init
- 280 ms before StartComm (compiled out)
- 25 ms KWP1281 ACK/end, CH340 low-baud frame remainder (fallback)
- ~200 ms 5-baud address bits (start/data/parity)

W4, fast-init 25+25 pulses, P4, and KWP1281 1–2 ms stay spins.

Fixes #104
