### PR TITLE
Issue #103: abort KWP write on BT/BB layout mismatch

### DIFF
--- a/Communication/KWP2000Actions.cs
+++ b/Communication/KWP2000Actions.cs
@@ -1089,6 +1089,13 @@ namespace Communication
             Debug.Assert(mFlashToolCode != "000000", "Flash tool code cannot be all zeros");
         }
 
+        /// <summary>
+        /// Set when RequestRoutineResults is GeneralReject or DownloadNotAccepted.
+        /// ME7 uses that NRC for persistent-data copy failure and for an erase range
+        /// that is not a union of physical sectors (BT vs BB). WriteExternalFlashOperation
+        /// treats a boot-cluster fail as Wrong Flash Layout; this flag is the
+        /// Sector Erase Failed prompt on other sectors.
+        /// </summary>
         public bool FailedBecauseOfPersistentData { get; private set; }
 
         public override bool Start()
@@ -1247,6 +1254,8 @@ namespace Communication
 
                 if (!handled)
                 {
+                    // Unhandled erase NRC. Boot-cluster geometry fails use GeneralReject /
+                    // DownloadNotAccepted and are classified in WriteExternalFlashOperation.
                     DisplayStatusMessage("Failed to erase flash memory. You may be using the wrong memory layout.", StatusMessageType.USER);
                     ActionCompleted(false);
                 }

--- a/Communication/KWP2000Operations.cs
+++ b/Communication/KWP2000Operations.cs
@@ -19,6 +19,8 @@ Contact by Email: tony@nefariousmotorsports.com
 */
 
 //#define LOG_PERFORMANCE
+// Treat boot-cluster checksums as a miss (diff-write on an unchanged image). Do not commit enabled.
+//#define FORCE_BOOT_CLUSTER_CHECKSUM_MISMATCH
 
 using System;
 using System.Collections.Generic;
@@ -1306,6 +1308,7 @@ namespace Communication
             public bool OnlyWriteNonMatchingSectors = false;
             public bool VerifyWrittenData = true;
             public bool EraseEntireFlashAtOnce = false;
+            public MemoryLayout FlashMemoryLayout;
 
             public SecurityAccessAction.SecurityAccessSettings SecuritySettings = new SecurityAccessAction.SecurityAccessSettings();
         }
@@ -1355,6 +1358,7 @@ namespace Communication
 
             mMaxBlockSize = TransferDataAction.DEFAULT_MAX_BLOCK_SIZE;
             mEraseEntireFlashAtOnce = writeSettings.EraseEntireFlashAtOnce;
+            mFlashMemoryLayout = writeSettings.FlashMemoryLayout;
             mValidatedEraseMode = false;
             mEncryptionType = TransferDataAction.EncryptionType.Bosch;
             mCompressionType = TransferDataAction.CompressionType.Bosch;
@@ -1388,6 +1392,28 @@ namespace Communication
             }
 
             mCurrentBlock = mFlashBlockList.First();
+        }
+
+        private bool ApplyEraseFailurePromptResult(UserPromptResult promptResult)
+        {
+            if (promptResult == UserPromptResult.YES)
+            {
+                CommInterface.DisplayStatusMessage("Erasing entire flash and restarting flashing process.", StatusMessageType.USER);
+
+                RestartFlashingProcessAndEraseEntireFlashAtOnce();
+                return true;
+            }
+
+            if (promptResult == UserPromptResult.NO)
+            {
+                CommInterface.DisplayStatusMessage("Skipping flash sector and continuing flashing process.", StatusMessageType.USER);
+
+                mCurrentBlock.mFlashComplete = true;
+                mState = FlashingState.FinishedBlock;
+                return true;
+            }
+
+            return false;
         }
 
         public bool OnlyFlashRequiredSectors { get; private set; }
@@ -1707,7 +1733,17 @@ namespace Communication
 
                         if (success)
                         {
-                            if (((ValidateFlashChecksumAction)action).IsFlashChecksumCorrect)
+                            bool checksumCorrect = ((ValidateFlashChecksumAction)action).IsFlashChecksumCorrect;
+#if FORCE_BOOT_CLUSTER_CHECKSUM_MISMATCH
+                            int sectorIndex = mFlashBlockList.IndexOf(mCurrentBlock);
+                            if (checksumCorrect && (mFlashMemoryLayout != null)
+                                && mFlashMemoryLayout.IsBootClusterSector(sectorIndex))
+                            {
+                                CommInterface.DisplayStatusMessage("FORCE_BOOT_CLUSTER_CHECKSUM_MISMATCH: treating boot-cluster sector as a checksum miss.", StatusMessageType.USER);
+                                checksumCorrect = false;
+                            }
+#endif
+                            if (checksumCorrect)
                             {
                                 mCurrentBlock.mFlashingIsRequired = false;
 
@@ -1819,7 +1855,32 @@ namespace Communication
                     {
                         if (!mEraseEntireFlashAtOnce)
                         {
-                            if (((EraseFlashAction)action).FailedBecauseOfPersistentData)
+                            int sectorIndex = mFlashBlockList.IndexOf(mCurrentBlock);
+                            MemoryLayout selectedLayout = mFlashMemoryLayout;
+
+                            if ((selectedLayout != null) && selectedLayout.IsBootClusterSector(sectorIndex))
+                            {
+                                uint startAddress = mCurrentBlock.mMemoryImage.StartAddress;
+                                uint sectorSize = mCurrentBlock.mMemoryImage.Size;
+                                uint endAddress = startAddress + sectorSize - 1;
+                                bool isTopBoot = (selectedLayout.BootOrientation == FlashBootOrientation.TopBoot);
+                                string selectedName = isTopBoot ? "top-boot (BT)" : "bottom-boot (BB)";
+                                string suspectedName = isTopBoot ? "bottom-boot (BB)" : "top-boot (BT)";
+                                string oppositeName = !String.IsNullOrEmpty(selectedLayout.OppositeLayout)
+                                    ? selectedLayout.OppositeLayout
+                                    : "the opposite boot layout";
+
+                                CommInterface.DisplayStatusMessage("Flash write failed: selected "
+                                    + selectedName + " layout, chip looks " + suspectedName + ".",
+                                    StatusMessageType.USER);
+
+                                CommInterface.DisplayUserPrompt("Wrong Flash Layout",
+                                    "Erase failed at 0x" + startAddress.ToString("X8") + "-0x" + endAddress.ToString("X8")
+                                    + ". Selected layout is " + selectedName + "; this chip looks " + suspectedName + "."
+                                    + " Re-flash with " + oppositeName + ".",
+                                    UserPromptType.OK);
+                            }
+                            else if (((EraseFlashAction)action).FailedBecauseOfPersistentData)
                             {
                                 var promptResult = CommInterface.DisplayUserPrompt("Sector Erase Failed",
                                     "Failed to erase the memory sector. The new data being flashed likely conflicts with the ECU's persistent data. The persistent ECU data can be replaced by erasing the entire flash memory before programming. If the ECU may contains a non-standard flash memory chip, it could be causing the erase to fail."
@@ -1829,21 +1890,7 @@ namespace Communication
                                     + "\n\nWARNING: Only erase the entire flash memory if you have a good communication connection with the ECU. If flashing fails after erasing the entire flash memory, it is likely the ECU will no longer boot, and will have to be reflashed on the bench using boot mode."
                                     + " This software does NOT support boot mode.", UserPromptType.YES_NO_CANCEL);
 
-                                if (promptResult == UserPromptResult.YES)
-                                {
-                                    CommInterface.DisplayStatusMessage("Erasing entire flash and restarting flashing process.", StatusMessageType.USER);
-
-                                    RestartFlashingProcessAndEraseEntireFlashAtOnce();
-                                    success = true;
-                                }
-                                else if (promptResult == UserPromptResult.NO)
-                                {
-                                    CommInterface.DisplayStatusMessage("Skipping flash sector and continuing flashing process.", StatusMessageType.USER);
-
-                                    mCurrentBlock.mFlashComplete = true;
-                                    mState = FlashingState.FinishedBlock;
-                                    success = true;
-                                }
+                                success = ApplyEraseFailurePromptResult(promptResult);
                             }
                             else//regular failure
                             {
@@ -2404,6 +2451,7 @@ namespace Communication
         private FlashBlock mCurrentBlock;
         private byte mMaxBlockSize;
         private bool mEraseEntireFlashAtOnce;
+        private MemoryLayout mFlashMemoryLayout;
         private bool mValidatedEraseMode;
         private bool mForcedLastSectorForECUCompletion;
 

--- a/ECUFlasher/FlashingControl.xaml.cs
+++ b/ECUFlasher/FlashingControl.xaml.cs
@@ -629,40 +629,7 @@ namespace ECUFlasher
 
         private string GetMemoryLayoutsDirectory()
         {
-            //Assembly.Location returns an empty string in a single-file build, so this fell through
-            //to the working directory and found no layouts at all. AppContext.BaseDirectory is the
-            //application's own folder in both single-file and regular builds.
-            string exeDir = AppContext.BaseDirectory;
-
-            if (!String.IsNullOrEmpty(exeDir))
-            {
-                string memoryLayoutsDir = Path.Combine(exeDir, "MemoryLayouts");
-
-                if (Directory.Exists(memoryLayoutsDir))
-                {
-                    return memoryLayoutsDir;
-                }
-
-                // Try parent directory (for development)
-                string parentDir = Path.GetDirectoryName(exeDir);
-                if (parentDir != null)
-                {
-                    memoryLayoutsDir = Path.Combine(parentDir, "MemoryLayouts");
-                    if (Directory.Exists(memoryLayoutsDir))
-                    {
-                        return memoryLayoutsDir;
-                    }
-                }
-            }
-
-            // Fallback to current directory
-            string currentDirMemoryLayouts = Path.Combine(Directory.GetCurrentDirectory(), "MemoryLayouts");
-            if (Directory.Exists(currentDirMemoryLayouts))
-            {
-                return currentDirMemoryLayouts;
-            }
-
-            return null;
+            return MemoryLayout.GetLayoutsDirectory();
         }
 
         private void PopulateMemoryLayouts()
@@ -2088,6 +2055,7 @@ namespace ECUFlasher
             settings.OnlyWriteNonMatchingSectors = diffWrite;
             settings.VerifyWrittenData = verify;
             settings.EraseEntireFlashAtOnce = false;
+            settings.FlashMemoryLayout = flashMemoryLayout;
             settings.SecuritySettings.RequestSeed = KWP2000CommViewModel.SeedRequest;
             settings.SecuritySettings.SupportSpecialKey = KWP2000CommViewModel.ShouldSupportSpecialKey;
             settings.SecuritySettings.UseExtendedSeedRequest = KWP2000CommViewModel.ShouldUseExtendedSeedRequest;
@@ -2424,7 +2392,7 @@ namespace ECUFlasher
         private static void AddWriteChecklistLines(List<string> lines, bool includeCommercialDisclaimer)
         {
             lines.Add("If you are ready to write, confirm the following things:");
-            lines.Add("1) You have loaded a valid file and memory layout for the ECU.");
+            lines.Add("1) You have loaded a valid file and memory layout for the ECU (top-boot vs bottom-boot must match the flash chip).");
             lines.Add("2) The engine is not running.");
             lines.Add("3) Battery voltage is at least 12 volts.");
             lines.Add("4) It is OK the ECU adaptation channels will be reset to defaults");

--- a/MemoryLayouts/ME7 29F200BB.MemoryLayout.xml
+++ b/MemoryLayouts/ME7 29F200BB.MemoryLayout.xml
@@ -4,6 +4,9 @@
   <BaseAddress>8388608</BaseAddress>
   <!--Size must be an even number and specified in decimal, hexidecimal is not currently supported. The Size comes from the memory chip datasheet.-->
   <Size>262144</Size>
+  <!--BootOrientation: TopBoot (BT) or BottomBoot (BB). Omit for uniform maps.-->
+  <BootOrientation>BottomBoot</BootOrientation>
+  <BootClusterSectors>4</BootClusterSectors>
   <!--SectorSizes must be an even number and specified in decimal, hexadecimal is not currently supported. The SectorSizes come from the memory chip datasheet. -->
   <SectorSizes>
     <unsignedInt>16384</unsignedInt>

--- a/MemoryLayouts/ME7 29F400BB.MemoryLayout.xml
+++ b/MemoryLayouts/ME7 29F400BB.MemoryLayout.xml
@@ -4,6 +4,9 @@
   <BaseAddress>8388608</BaseAddress>
   <!--Size must be an even number and specified in decimal, hexidecimal is not currently supported. The Size comes from the memory chip datasheet.-->
   <Size>524288</Size>
+  <!--BootOrientation: TopBoot (BT) or BottomBoot (BB). Omit for uniform maps.-->
+  <BootOrientation>BottomBoot</BootOrientation>
+  <BootClusterSectors>4</BootClusterSectors>
   <!--SectorSizes must be an even number and specified in decimal, hexadecimal is not currently supported. The SectorSizes come from the memory chip datasheet. -->
   <SectorSizes>
     <unsignedInt>16384</unsignedInt>

--- a/MemoryLayouts/ME7 29F800BB.MemoryLayout.xml
+++ b/MemoryLayouts/ME7 29F800BB.MemoryLayout.xml
@@ -4,6 +4,10 @@
   <BaseAddress>8388608</BaseAddress>
   <!--Size must be an even number and specified in decimal, hexidecimal is not currently supported. The Size comes from the memory chip datasheet.-->
   <Size>1048576</Size>
+  <!--BootOrientation: TopBoot (BT) or BottomBoot (BB). Omit for uniform maps.-->
+  <BootOrientation>BottomBoot</BootOrientation>
+  <BootClusterSectors>4</BootClusterSectors>
+  <OppositeLayout>ME7 29F800BT</OppositeLayout>
   <!--SectorSizes must be an even number and specified in decimal, hexadecimal is not currently supported. The SectorSizes come from the memory chip datasheet. -->
   <SectorSizes>
     <unsignedInt>16384</unsignedInt>

--- a/MemoryLayouts/ME7 29F800BT.MemoryLayout.xml
+++ b/MemoryLayouts/ME7 29F800BT.MemoryLayout.xml
@@ -4,6 +4,10 @@
   <BaseAddress>8388608</BaseAddress>
   <!--Size must be an even number and specified in decimal, hexidecimal is not currently supported. The Size comes from the memory chip datasheet.-->
   <Size>1048576</Size>
+  <!--BootOrientation: TopBoot (BT) or BottomBoot (BB). Omit for uniform maps.-->
+  <BootOrientation>TopBoot</BootOrientation>
+  <BootClusterSectors>4</BootClusterSectors>
+  <OppositeLayout>ME7 29F800BB</OppositeLayout>
   <!--SectorSizes must be an even number and specified in decimal, hexadecimal is not currently supported. The SectorSizes come from the memory chip datasheet. -->
   <SectorSizes>
     <unsignedInt>65536</unsignedInt>

--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ Open-source tool for reading, writing, and tuning VW/Audi ME7 ECUs via KWP2000
 
 ### Known Issues
 
-- [Issue #95](https://github.com/NefMoto/NefMotoOpenSource/issues/95) — in-car slow init can miss the KWP2000 address complement.
-- [Issue #100](https://github.com/NefMoto/NefMotoOpenSource/issues/100) — KWP write hang after ident (connect already up). Separate from #95.
+- [Issue #100](https://github.com/NefMoto/NefMotoOpenSource/issues/100) — KWP write hang after ident (connect already up).
+- [Issue #103](https://github.com/NefMoto/NefMotoOpenSource/issues/103) — KWP write with the wrong BT/BB layout used to look like a persistent-data erase failure. The write now aborts with **Wrong Flash Layout**. Pick the opposite layout (for example `ME7 29F800BB` instead of `ME7 29F800BT`) and write again with checksum skip. Switching layout in the same session is not implemented.
 - Other issues: [GitHub Issues](https://github.com/NefMoto/NefMotoOpenSource/issues)
 
 ## Building

--- a/Shared/MemoryLayout.cs
+++ b/Shared/MemoryLayout.cs
@@ -28,6 +28,13 @@ using System.Reflection;
 
 namespace Shared
 {
+    public enum FlashBootOrientation
+    {
+        Unknown,
+        TopBoot,
+        BottomBoot
+    }
+
     [Serializable]
     public class MemoryLayout : IDataErrorInfo
     {
@@ -53,12 +60,39 @@ namespace Shared
         {
             BaseAddress = 0;
             Size = 0;
+            BootOrientation = FlashBootOrientation.Unknown;
+            BootClusterSectors = 0;
+            OppositeLayout = null;
             SectorSizes.Clear();
             Validate();
         }
 
         public uint BaseAddress { get; set; }
         public uint Size { get; set; }
+
+        /// <summary>TopBoot (BT) or BottomBoot (BB). Omit for uniform maps.</summary>
+        public FlashBootOrientation BootOrientation { get; set; }
+
+        /// <summary>Small boot-block count at the BT top or BB bottom. Omit when BootOrientation is omitted.</summary>
+        public int BootClusterSectors { get; set; }
+
+        /// <summary>Dropdown basename of the opposite BT/BB layout, if one is shipped.</summary>
+        public string OppositeLayout { get; set; }
+
+        public bool ShouldSerializeBootOrientation()
+        {
+            return BootOrientation != FlashBootOrientation.Unknown;
+        }
+
+        public bool ShouldSerializeBootClusterSectors()
+        {
+            return BootClusterSectors != 0;
+        }
+
+        public bool ShouldSerializeOppositeLayout()
+        {
+            return !String.IsNullOrEmpty(OppositeLayout);
+        }
 
         private bool ValidateBaseAddress()
         {
@@ -137,13 +171,81 @@ namespace Shared
             return (error == null);
         }
 
+        private bool ValidateBootMetadata()
+        {
+            string error = null;
+            if ((BootOrientation == FlashBootOrientation.TopBoot) || (BootOrientation == FlashBootOrientation.BottomBoot))
+            {
+                if ((BootClusterSectors < 1) || (SectorSizes == null) || (BootClusterSectors > SectorSizes.Count))
+                {
+                    error = "BootClusterSectors must be between 1 and the number of sectors";
+                }
+            }
+            this["BootOrientation"] = error;
+            return (error == null);
+        }
+
         public bool Validate()
         {
             bool isValid = ValidateBaseAddress();
             isValid &= ValidateSize();
             isValid &= ValidateSectorSizes();
+            isValid &= ValidateBootMetadata();
 
             return isValid;
+        }
+
+        /// <summary>
+        /// Directory next to the executable (or repo/working tree) that holds *.MemoryLayout.xml.
+        /// AppContext.BaseDirectory works for single-file and regular builds; Assembly.Location does not.
+        /// </summary>
+        public static string GetLayoutsDirectory()
+        {
+            string exeDir = AppContext.BaseDirectory;
+
+            if (!String.IsNullOrEmpty(exeDir))
+            {
+                string memoryLayoutsDir = Path.Combine(exeDir, "MemoryLayouts");
+                if (Directory.Exists(memoryLayoutsDir))
+                {
+                    return memoryLayoutsDir;
+                }
+
+                string parentDir = Path.GetDirectoryName(exeDir);
+                if (parentDir != null)
+                {
+                    memoryLayoutsDir = Path.Combine(parentDir, "MemoryLayouts");
+                    if (Directory.Exists(memoryLayoutsDir))
+                    {
+                        return memoryLayoutsDir;
+                    }
+                }
+            }
+
+            string currentDirMemoryLayouts = Path.Combine(Directory.GetCurrentDirectory(), "MemoryLayouts");
+            if (Directory.Exists(currentDirMemoryLayouts))
+            {
+                return currentDirMemoryLayouts;
+            }
+
+            return null;
+        }
+
+        public bool IsBootClusterSector(int index)
+        {
+            if ((BootClusterSectors <= 0) || (SectorSizes == null) || (index < 0) || (index >= SectorSizes.Count))
+            {
+                return false;
+            }
+            if (BootOrientation == FlashBootOrientation.BottomBoot)
+            {
+                return index < BootClusterSectors;
+            }
+            if (BootOrientation == FlashBootOrientation.TopBoot)
+            {
+                return index >= (SectorSizes.Count - BootClusterSectors);
+            }
+            return false;
         }
 
         public string Error

--- a/Tests/MemoryLayoutBootTests.cs
+++ b/Tests/MemoryLayoutBootTests.cs
@@ -1,0 +1,163 @@
+/*
+Nefarious Motorsports ME7 ECU Flasher
+Copyright (C) 2026  Nefarious Motorsports Inc
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Contact by Email: nyet@nyet.org
+*/
+
+using System.Collections.Generic;
+using System.IO;
+using System.Xml.Serialization;
+using Shared;
+using Xunit;
+
+namespace NefMotoOpenSource.Tests;
+
+public sealed class MemoryLayoutBootTests
+{
+    private const uint Size8K = 8192;
+    private const uint Size16K = 16384;
+    private const uint Size32K = 32768;
+    private const uint Size64K = 65536;
+
+    public static List<uint> F800BT()
+    {
+        return Concat(Repeat(Size64K, 15), new uint[] { Size32K, Size8K, Size8K, Size16K });
+    }
+
+    public static List<uint> F800BB()
+    {
+        return Concat(new uint[] { Size16K, Size8K, Size8K, Size32K }, Repeat(Size64K, 15));
+    }
+
+    public static List<uint> F400BB()
+    {
+        return Concat(new uint[] { Size16K, Size8K, Size8K, Size32K }, Repeat(Size64K, 7));
+    }
+
+    [Fact]
+    public void IsBootClusterSector_BT_OnlyLastFour()
+    {
+        var layout = BootLayout(F800BT(), 1024 * 1024, FlashBootOrientation.TopBoot, 4);
+        Assert.False(layout.IsBootClusterSector(0));
+        Assert.False(layout.IsBootClusterSector(14));
+        Assert.True(layout.IsBootClusterSector(15));
+        Assert.True(layout.IsBootClusterSector(18));
+        Assert.False(layout.IsBootClusterSector(-1));
+        Assert.False(layout.IsBootClusterSector(19));
+    }
+
+    [Fact]
+    public void IsBootClusterSector_BB_OnlyFirstFour()
+    {
+        var layout = BootLayout(F800BB(), 1024 * 1024, FlashBootOrientation.BottomBoot, 4);
+        Assert.True(layout.IsBootClusterSector(0));
+        Assert.True(layout.IsBootClusterSector(3));
+        Assert.False(layout.IsBootClusterSector(4));
+        Assert.False(layout.IsBootClusterSector(18));
+    }
+
+    [Fact]
+    public void IsBootClusterSector_Uniform64K_Never()
+    {
+        var layout = new MemoryLayout(0x800000, Size64K * 16, Repeat(Size64K, 16));
+        Assert.True(layout.Validate(), layout.Error);
+        Assert.False(layout.IsBootClusterSector(0));
+        Assert.False(layout.IsBootClusterSector(15));
+    }
+
+    [Fact]
+    public void IsBootClusterSector_F400BT_UsesClusterCount()
+    {
+        var sizes = Concat(Repeat(Size64K, 7), new uint[] { Size32K, Size8K, Size8K, Size16K });
+        var layout = BootLayout(sizes, 512 * 1024, FlashBootOrientation.TopBoot, 4);
+        Assert.True(layout.IsBootClusterSector(7));
+        Assert.False(layout.IsBootClusterSector(6));
+    }
+
+    [Fact]
+    public void Validate_BootOrientationWithoutClusterCount_Fails()
+    {
+        var layout = new MemoryLayout(0x800000, 1024 * 1024, F800BT());
+        layout.BootOrientation = FlashBootOrientation.TopBoot;
+        Assert.False(layout.Validate());
+    }
+
+    [Fact]
+    public void ShippedLayoutXml_HasBootMetadata()
+    {
+        string dir = MemoryLayout.GetLayoutsDirectory();
+        Assert.False(string.IsNullOrEmpty(dir));
+
+        var bt = DeserializeLayout(dir, "ME7 29F800BT");
+        Assert.Equal(FlashBootOrientation.TopBoot, bt.BootOrientation);
+        Assert.Equal(4, bt.BootClusterSectors);
+        Assert.Equal("ME7 29F800BB", bt.OppositeLayout);
+        Assert.True(bt.IsBootClusterSector(15));
+        Assert.False(bt.IsBootClusterSector(14));
+
+        var bb = DeserializeLayout(dir, "ME7 29F800BB");
+        Assert.Equal(FlashBootOrientation.BottomBoot, bb.BootOrientation);
+        Assert.Equal("ME7 29F800BT", bb.OppositeLayout);
+        Assert.True(bb.IsBootClusterSector(0));
+        Assert.False(bb.IsBootClusterSector(4));
+
+        var f400 = DeserializeLayout(dir, "ME7 29F400BB");
+        Assert.Equal(FlashBootOrientation.BottomBoot, f400.BootOrientation);
+        Assert.True(string.IsNullOrEmpty(f400.OppositeLayout));
+        Assert.True(f400.IsBootClusterSector(3));
+    }
+
+    private static MemoryLayout BootLayout(IList<uint> sizes, uint size, FlashBootOrientation orientation, int clusterSectors)
+    {
+        var layout = new MemoryLayout(0x800000, size, new List<uint>(sizes));
+        layout.BootOrientation = orientation;
+        layout.BootClusterSectors = clusterSectors;
+        Assert.True(layout.Validate(), layout.Error);
+        return layout;
+    }
+
+    private static MemoryLayout DeserializeLayout(string directory, string basename)
+    {
+        string path = Path.Combine(directory, basename + MemoryLayout.MEMORY_LAYOUT_FILE_EXT);
+        using (var stream = File.OpenRead(path))
+        {
+            var layout = Assert.IsType<MemoryLayout>(new XmlSerializer(typeof(MemoryLayout)).Deserialize(stream));
+            Assert.True(layout.Validate(), layout.Error);
+            return layout;
+        }
+    }
+
+    private static List<uint> Repeat(uint size, int count)
+    {
+        var list = new List<uint>(count);
+        for (int i = 0; i < count; i++)
+        {
+            list.Add(size);
+        }
+        return list;
+    }
+
+    private static List<uint> Concat(IList<uint> a, IList<uint> b)
+    {
+        var list = new List<uint>(a.Count + b.Count);
+        list.AddRange(a);
+        list.AddRange(b);
+        return list;
+    }
+}
+
+// vi: set sw=4 ts=8 expandtab:

--- a/Tests/NefMotoOpenSource.Tests.csproj
+++ b/Tests/NefMotoOpenSource.Tests.csproj
@@ -20,4 +20,7 @@
     <ProjectReference Include="..\Communication\Communication.csproj" />
     <ProjectReference Include="..\Shared\Shared.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <Content Include="..\MemoryLayouts\*.MemoryLayout.xml" Link="MemoryLayouts\%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
 </Project>

--- a/docs/KWP2000.md
+++ b/docs/KWP2000.md
@@ -29,6 +29,14 @@ If the check finds different data, the layout is likely too small (use **ME7 29F
 
 Example: `06A 906 032 CL` (2001 Golf/Jetta 1.8T AWD, narrowband / 512KB) — [issue #80](https://github.com/NefMoto/NefMotoOpenSource/issues/80).
 
+### Flash layout (BT vs BB)
+
+29F800 / 29F400 / 29F200 exist as **top-boot (BT)** and **bottom-boot (BB)**. Same density, different small-sector cluster. KWP has no flash device ID; the user picks the XML. Bootmode already maps BT/BB from `FC_GETSTATE`.
+
+These bench 29F800 units are **BB** (`ME7 29F800BB`). A KWP write with `ME7 29F800BT` can program the first 15 × 64KB (legal unions on BB), then fail erasing `0x8F0000`–`0x8F7FFF`. Status is one line (`Flash write failed: selected top-boot (BT) layout, chip looks bottom-boot (BB).`). Dialog **Wrong Flash Layout** (OK only); the write aborts. Recovery: pick the named opposite layout and write again with checksum skip. Entire-flash erase still uses the current sector list and does not fix BT vs BB.
+
+The same erase NRC used to open **Sector Erase Failed** (persistent data). Uniform `ME7 29F800` (16 × 64KB) is a different mismatch. Switching layout in the same programming session is not implemented ([issue #103](https://github.com/NefMoto/NefMotoOpenSource/issues/103)).
+
 ---
 
 ## Results (defaults)
@@ -139,3 +147,4 @@ Legacy **`AllowCh340SlowInit`** is removed (ignored in old user.config). CH340 s
 - [issue #44](https://github.com/NefMoto/NefMotoOpenSource/issues/44) — CH340 bootmode baud
 - [issue #76](https://github.com/NefMoto/NefMotoOpenSource/issues/76) — CH340 slow init
 - [issue #95](https://github.com/NefMoto/NefMotoOpenSource/issues/95) — in-car address complement miss
+- [issue #103](https://github.com/NefMoto/NefMotoOpenSource/issues/103) — KWP BT/BB layout mismatch on write


### PR DESCRIPTION
ME7 rejects a mid-sector erase with the same NRC as persistent-data copy failure, so a BT XML on a BB chip opened Sector Erase Failed.

Classify a boot-cluster erase fail from the selected layout XML (BootOrientation, BootClusterSectors, OppositeLayout). Status is one line; Wrong Flash Layout is OK-only and the write stays failed.

Recover by picking the opposite layout and writing again with checksum skip.

Does not switch layout in-session.