### PR TITLE
ci: Restore WiX as a local tool and smoke the MSI on PRs

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "wix": {
+      "version": "6.0.2",
+      "commands": [
+        "wix"
+      ]
+    }
+  }
+}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,5 @@
 name: Build
 
-env:
-  WIX_VERSION: '6.0.2'
-
 on:
   push:
     branches:
@@ -38,7 +35,9 @@ jobs:
 
   installer:
     runs-on: windows-latest
-    if: startsWith(github.ref, 'refs/tags/')
+    # PRs (including synchronize / force-push) and pushes to the default branch.
+    # Not tags — v* MSI is release.yml only. Do not use push: branches: '**' (double-run with pull_request).
+    if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch))
 
     steps:
     - name: Checkout code
@@ -51,17 +50,6 @@ jobs:
       with:
         dotnet-version: '10.0.x'
 
-    - name: Setup Python
-      uses: actions/setup-python@v7
-      with:
-        python-version: '3.x'
-
-    - name: Install WiX Toolset
-      run: |
-        dotnet tool install --global wix --version ${{ env.WIX_VERSION }}
-        wix extension add WixToolset.UI.wixext/${{ env.WIX_VERSION }} WixToolset.NetFx.wixext/${{ env.WIX_VERSION }} --global
-      shell: pwsh
-
     - name: Build installer
       run: make installer
       shell: bash
@@ -71,4 +59,4 @@ jobs:
       with:
         name: NefMotoECUFlasher-installer
         path: Installer/bin/Release/NefMotoECUFlasher-*.msi
-        retention-days: 90
+        retention-days: 14

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,5 @@
 name: Release
 
-env:
-  WIX_VERSION: '6.0.2'
-
 on:
   push:
     tags:
@@ -65,17 +62,6 @@ jobs:
       with:
         dotnet-version: '10.0.x'
 
-    - name: Setup Python
-      uses: actions/setup-python@v7
-      with:
-        python-version: '3.x'
-
-    - name: Install WiX Toolset
-      run: |
-        dotnet tool install --global wix --version ${{ env.WIX_VERSION }}
-        wix extension add WixToolset.UI.wixext/${{ env.WIX_VERSION }} WixToolset.NetFx.wixext/${{ env.WIX_VERSION }} --global
-      shell: pwsh
-
     - name: Build Release
       run: make release
       shell: bash
@@ -92,10 +78,9 @@ jobs:
       shell: bash
 
     - name: Install git-cliff
-      uses: kenji-miyake/setup-git-cliff@v2
+      uses: taiki-e/install-action@v2
       with:
-        target-platform: x86_64-pc-windows-msvc
-        archive-extension: zip
+        tool: git-cliff
 
     - name: Find MSI file
       id: find_msi

--- a/Makefile
+++ b/Makefile
@@ -36,14 +36,11 @@ build:
 	@echo "Building with dotnet ($(CONFIG))..."
 	FULL_VERSION=$(FULL_VERSION) dotnet build ECUFlasher.sln --configuration $(CONFIG) --verbosity minimal
 
-installer $(INSTALLER): $(RELEASE_DIR)/NefMotoECUFlasher.exe Installer/Product.wxs Makefile Directory.Build.props
+installer $(INSTALLER): $(RELEASE_DIR)/NefMotoECUFlasher.exe Installer/Product.wxs Makefile Directory.Build.props .config/dotnet-tools.json installer.ps1
 	@echo "Building $(INSTALLER) ($(FULL_VERSION), $(NET_TFM))..."
-	@mkdir -p Installer/bin/Release
-	@ECUFlasher_TargetDir="$(RELEASE_DIR)/" \
-	FULL_VERSION=$(FULL_VERSION) wix build -arch x64 \
-		-d RuntimeTfm=$(NET_TFM) -d DotNetMajor=$(DOTNET_MAJOR) \
-		-ext WixToolset.UI.wixext -ext WixToolset.NetFx.wixext \
-		-o $(INSTALLER) Installer/Product.wxs
+	@FULL_VERSION=$(FULL_VERSION) NET_TFM=$(NET_TFM) DOTNET_MAJOR=$(DOTNET_MAJOR) \
+	ECUFlasher_TargetDir="$(RELEASE_DIR)/" \
+	powershell.exe -NoProfile -ExecutionPolicy Bypass -File installer.ps1
 
 # Framework-dependent publish folder (not single-file, not the MSI). Still needs the Desktop runtime matching NetTfm.
 publish:

--- a/build.bat
+++ b/build.bat
@@ -38,13 +38,10 @@ if "%1"=="publish" (
     )
 )
 
-REM If installer argument provided, build installer
 if "%1"=="installer" (
     set ECUFlasher_TargetDir=ECUFlasher/bin/msil/Release/
-    echo Building installer/bin/Release/NefMotoECUFlasher-%FULL_VERSION%.msi...
-    wix build -arch x64 -d RuntimeTfm=%NET_TFM% -d DotNetMajor=%DOTNET_MAJOR% -ext WixToolset.UI.wixext -ext WixToolset.NetFx.wixext -o Installer/bin/Release/NefMotoECUFlasher-%FULL_VERSION%.msi Installer/Product.wxs
+    powershell.exe -NoProfile -ExecutionPolicy Bypass -File installer.ps1
     if errorlevel 1 exit /b %ERRORLEVEL%
 )
-
 echo Done!
 exit /b 0

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -43,9 +43,6 @@ build.bat publish
 
 - **.NET 10 SDK** (preferred) or **Visual Studio** with MSBuild. End users of the MSI need the **.NET 10 Desktop Runtime**, not only the console runtime.
 - Target framework is `NetTfm` in [`Directory.Build.props`](../Directory.Build.props). Output dirs do not include the TFM (`ECUFlasher/bin/msil/Debug` / `Release`).
-- **WiX Toolset v6.0+** (for installer builds; MSI is **x64**, `-arch x64`)
-  - `dotnet tool install --global wix --version 6.0.2`
-- **WiX UI and NetFX extensions**
-  - `wix extension add WixToolset.UI.wixext WixToolset.NetFx.wixext --global`
+- **WiX Toolset** (installer builds; MSI is **x64**, `-arch x64`). Version is [`.config/dotnet-tools.json`](../.config/dotnet-tools.json) (Dependabot can bump it). [`installer.ps1`](../installer.ps1) runs `dotnet tool restore` then `dotnet tool run wix` — no global `wix` on `PATH`. `make installer` and `build.bat installer` both invoke that script. UI and NetFx extensions are added at the json version during the installer build.
 
 `make publish` / `build.bat publish` writes a framework-dependent copy to `publish/NefMotoECUFlasher`. It is not a substitute for the MSI: no shortcuts, no installer .NET check, and it still needs the .NET 10 Desktop runtime. `MemoryLayouts` is copied next to the executable. This is not a single-file exe.

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -51,20 +51,20 @@ To rebuild an existing tag without moving it, use **Actions → Release → Run 
 
 ## CI workflows
 
-| Workflow          | Triggers                               | What it does                                      |
-|-------------------|----------------------------------------|---------------------------------------------------|
-| **`build.yml`**   | Push/PR to any branch; push of any tag | Build and test; MSI artifact on tag push          |
-| **`release.yml`** | Push of `v*` tags; `workflow_dispatch` | Build, test, MSI, release notes, GitHub release   |
+| Workflow          | Triggers                                         | What it does                                                        |
+|-------------------|--------------------------------------------------|---------------------------------------------------------------------|
+| **`build.yml`**   | Push/PR to any branch; push of any tag           | Build and test on all of those. MSI smoke on **PRs** and **pushes to the default branch** (artifact kept 14 days). No MSI on tags. |
+| **`release.yml`** | Push of `v*` tags (stable and RC); `workflow_dispatch` | Build, test, MSI, release notes, GitHub release                 |
 
-`build.yml` retains MSI workflow artifacts for 90 days; `release.yml` is what publishes the installer on GitHub Releases.
+`release.yml` is what publishes the installer on GitHub Releases. `build.yml` does not upload an MSI on tag push.
 
 The generated **Downloads** section includes a .NET 10 Desktop Runtime (x64) requirement (and a note that .NET 8 Desktop is not enough). Keep that in sync with README **Requirements**. The MSI is **x64** and installs to Program Files; upgrading from an older x86 MSI should uninstall the Program Files (x86) copy.
 
 ### What `release.yml` does
 
 1. **Determine tag type** — Tags with a hyphen suffix (e.g. `-rc1`) are pre-releases. Finds `prev_tag` (nearest ancestor tag from the tagged commit’s parent, often the prior RC) for RC changelog ranges.
-2. **Build** — `make release`, `make test CONFIG=Release`, `make installer` (WiX 6).
-3. **Release notes** — [git-cliff](https://git-cliff.org) via `kenji-miyake/setup-git-cliff@v2` (version not pinned):
+2. **Build** — `make release`, `make test CONFIG=Release`, `make installer` ([`installer.ps1`](../installer.ps1): local WiX from [`.config/dotnet-tools.json`](../.config/dotnet-tools.json) via `dotnet tool restore` / `dotnet tool run wix`).
+3. **Release notes** — [git-cliff](https://git-cliff.org) via [`taiki-e/install-action@v2`](https://github.com/taiki-e/install-action) (`tool: git-cliff` in `release.yml`, unpinned). The tool version follows that action’s manifests (cooldown of a day or so), not a live GitHub release every job. Dependabot only updates the action, which is how cliff moves. **Blind spot:** there is no PR smoke for notes without churning temporary tags. An RC job that fails to generate notes (including a future 3.0) is the smoke; fix `cliff.toml` or the notes bash before the full tag. Do not add a fake-tag notes job.
    - **Stable:** `git cliff -l` — changelog since the previous stable tag (`tag_pattern` in `cliff.toml`).
    - **Pre-release:** `git cliff $prev_tag..$tag` — commits since the previous tag on the line (often the prior RC). CI replaces git-cliff’s first line so the header reads `(since $prev_tag)`; git-cliff alone still prints the last **stable** tag there.
 4. **Publish** — Deletes any existing GitHub release for the tag (re-tag / re-run), appends a `## Downloads` section with the MSI link and .NET 10 Desktop Runtime requirement, then creates the release via `softprops/action-gh-release@v3`.

--- a/installer.ps1
+++ b/installer.ps1
@@ -1,0 +1,17 @@
+# Called by Makefile and build.bat. Requires FULL_VERSION, NET_TFM, DOTNET_MAJOR, ECUFlasher_TargetDir.
+$ErrorActionPreference = 'Stop'
+Set-Location $PSScriptRoot
+
+$wixVersion = (Get-Content .config/dotnet-tools.json -Raw | ConvertFrom-Json).tools.wix.version
+if (-not $wixVersion) { throw 'wix version missing from .config/dotnet-tools.json' }
+
+$msi = "Installer/bin/Release/NefMotoECUFlasher-$($env:FULL_VERSION).msi"
+New-Item -ItemType Directory -Force -Path Installer/bin/Release | Out-Null
+Write-Host "WiX $wixVersion (local tool), $msi"
+
+dotnet tool restore
+if ($LASTEXITCODE) { exit $LASTEXITCODE }
+dotnet tool run wix -- extension add "WixToolset.UI.wixext/$wixVersion" "WixToolset.NetFx.wixext/$wixVersion" --global
+if ($LASTEXITCODE) { exit $LASTEXITCODE }
+dotnet tool run wix -- build -arch x64 -d "RuntimeTfm=$($env:NET_TFM)" -d "DotNetMajor=$($env:DOTNET_MAJOR)" -ext WixToolset.UI.wixext -ext WixToolset.NetFx.wixext -o $msi Installer/Product.wxs
+if ($LASTEXITCODE) { exit $LASTEXITCODE }


### PR DESCRIPTION
Share one WiX version via .config/dotnet-tools.json (dotnet tool restore / run) so Product.wxs and Dependabot WiX bumps fail on the PR instead of at a v* tag.

Stop building the MSI twice on release tags; replace archived setup-git-cliff with taiki-e/install-action (git-cliff unpinned; an RC notes failure is the smoke).