### PR TITLE
refactor: make Shared/Communication UI-agnostic for future Avalonia head

### DIFF
--- a/Communication/Communication.csproj
+++ b/Communication/Communication.csproj
@@ -2,8 +2,6 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <UseWPF>true</UseWPF>
-    <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <OutputPath>bin\msil\Debug\</OutputPath>

--- a/Communication/KWP2000ExtendedDataLogging.cs
+++ b/Communication/KWP2000ExtendedDataLogging.cs
@@ -26,8 +26,6 @@ using System.Threading;
 using System.Linq;
 using System.Runtime.Serialization.Formatters.Binary;
 using System.IO;
-using System.Windows.Data;
-
 using Shared;
 
 namespace Communication

--- a/Communication/KWP2000Operations.cs
+++ b/Communication/KWP2000Operations.cs
@@ -30,8 +30,6 @@ using System.Threading;
 using System.Linq;
 using System.Runtime.Serialization.Formatters.Binary;
 using System.IO;
-using System.Windows.Data;
-
 using Shared;
 
 namespace Communication
@@ -242,7 +240,7 @@ namespace Communication
                                             {
                                                 if ((((byte)flashStatus.mProgrammingSessionPreconditions) & ((byte)precondition)) != 0)
                                                 {
-                                                    string reasonDescription = "-" + DescriptionAttributeConverter.GetDescriptionAttribute(precondition);
+                                                    string reasonDescription = "-" + DescriptionAttributeConverterLogic.GetDescriptionAttribute(precondition);
                                                     CommInterface.DisplayStatusMessage(reasonDescription, StatusMessageType.USER);
 
                                                     reasons += "\n" + reasonDescription;

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,9 +1,16 @@
 <Project>
   <PropertyGroup>
-    <!-- Single TFM source of truth. FTD2XX_NET is netX.0 (no WPF); everything else is netX.0-windows. -->
+    <!-- Single TFM source of truth. Shared libs/tests are netX.0 (no WPF); ECUFlasher is netX.0-windows. -->
     <NetTfm>net10.0</NetTfm>
-    <TargetFramework Condition="'$(MSBuildProjectName)' == 'FTD2XX_NET'">$(NetTfm)</TargetFramework>
-    <TargetFramework Condition="'$(MSBuildProjectName)' != 'FTD2XX_NET'">$(NetTfm)-windows</TargetFramework>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
+    <IsNonWindowsTfm Condition="'$(MSBuildProjectName)' == 'FTD2XX_NET'">true</IsNonWindowsTfm>
+    <IsNonWindowsTfm Condition="'$(MSBuildProjectName)' == 'Shared'">true</IsNonWindowsTfm>
+    <IsNonWindowsTfm Condition="'$(MSBuildProjectName)' == 'Communication'">true</IsNonWindowsTfm>
+    <IsNonWindowsTfm Condition="'$(MSBuildProjectName)' == 'Checksum'">true</IsNonWindowsTfm>
+    <IsNonWindowsTfm Condition="'$(MSBuildProjectName)' == 'ApplicationShared'">true</IsNonWindowsTfm>
+    <IsNonWindowsTfm Condition="'$(MSBuildProjectName)' == 'NefMotoOpenSource.Tests'">true</IsNonWindowsTfm>
+    <TargetFramework Condition="'$(IsNonWindowsTfm)' == 'true'">$(NetTfm)</TargetFramework>
+    <TargetFramework Condition="'$(IsNonWindowsTfm)' != 'true'">$(NetTfm)-windows</TargetFramework>
     <!-- Keep bin paths stable across TFM bumps (Makefile, WiX, launch.json). -->
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>

--- a/ECUFlasher/App.xaml
+++ b/ECUFlasher/App.xaml
@@ -25,15 +25,15 @@ Contact by Email: tony@nefariousmotorsports.com
     xmlns:ECUFlasher="clr-namespace:ECUFlasher"
     xmlns:props="clr-namespace:ECUFlasher.Properties"
     xmlns:Communication="clr-namespace:Communication;assembly=Communication"
-    xmlns:Shared="clr-namespace:Shared;assembly=ECUShared"
+    xmlns:SharedUi="clr-namespace:Shared"
     StartupUri="MainWindow.xaml">
     <Application.Resources>
 
         <ECUFlasher:IsBaudRateUndefinedConverter x:Key="isKWP2000BaudRateUndefinedConverer"/>
-        <Shared:DescriptionAttributeConverter x:Key="descriptionAttributeConverter"/>
-        <Shared:HexConverter x:Key="hexConverter"/>
-        <Shared:AsStringConverter x:Key="asStringConverter"/>
-        <Shared:StringValidConverter x:Key="stringValidConverter"/>
+        <SharedUi:DescriptionAttributeConverter x:Key="descriptionAttributeConverter"/>
+        <SharedUi:HexConverter x:Key="hexConverter"/>
+        <SharedUi:AsStringConverter x:Key="asStringConverter"/>
+        <SharedUi:StringValidConverter x:Key="stringValidConverter"/>
         <ECUFlasher:IsConnectionOpenConverter x:Key="isConnectionOpenConverter"/>
         <ECUFlasher:ProgressBarWidthConverter x:Key="progressBarWidthConverter"/>
 

--- a/ECUFlasher/DataLoggerControl.xaml
+++ b/ECUFlasher/DataLoggerControl.xaml
@@ -27,6 +27,7 @@ Contact by Email: tony@nefariousmotorsports.com
             xmlns:scm="clr-namespace:System.ComponentModel;assembly=WindowsBase"
             xmlns:ECUFlasher="clr-namespace:ECUFlasher"
             xmlns:Shared="clr-namespace:Shared;assembly=ECUShared"
+            xmlns:SharedUi="clr-namespace:Shared"
             xmlns:props="clr-namespace:ECUFlasher.Properties"
             mc:Ignorable="d"
             d:DesignHeight="300" d:DesignWidth="300"
@@ -38,8 +39,8 @@ Contact by Email: tony@nefariousmotorsports.com
         <Color x:Key="VariableDefinitionsListErrorBackgroundColor">Gray</Color>
         <SolidColorBrush x:Key="VariableDefinitionsListErrorBackgroundBrush" Color="{StaticResource VariableDefinitionsListErrorBackgroundColor}"/>
 
-        <Shared:TimeSpanSecondsConverter x:Key="timeSpanSecondsConverter"/>
-        <Shared:TimeSpanStringFormatConverter x:Key="timeSpanStringFormatConverter"/>
+        <SharedUi:TimeSpanSecondsConverter x:Key="timeSpanSecondsConverter"/>
+        <SharedUi:TimeSpanStringFormatConverter x:Key="timeSpanStringFormatConverter"/>
 
         <ObjectDataProvider MethodName="GetValues" ObjectType="{x:Type sys:Enum}" x:Key="DataTypeEnumValues">
             <ObjectDataProvider.MethodParameters>
@@ -62,7 +63,7 @@ Contact by Email: tony@nefariousmotorsports.com
         </DataTemplate>
 
         <CollectionViewSource Source="{Binding Path=VariableDefinitions}" Filter="ResortRenamedVariablesFilter" x:Key="AlphabeticalVariableDefinitions"
-            Shared:ViewSourceHelper.AutoSelectNewItems="True">
+            SharedUi:ViewSourceHelper.AutoSelectNewItems="True">
             <CollectionViewSource.SortDescriptions>
                 <scm:SortDescription PropertyName="Name"/>
             </CollectionViewSource.SortDescriptions>
@@ -438,7 +439,7 @@ Contact by Email: tony@nefariousmotorsports.com
                                     <RowDefinition Height="Auto"></RowDefinition>
                                 </Grid.RowDefinitions>
                                 <ListBox Name="VariableDefinitionsListBox" Grid.Row="0" IsSynchronizedWithCurrentItem="True" SelectionMode="Extended" ItemsSource="{Binding Source={StaticResource AlphabeticalVariableDefinitions}}" Background="Transparent"
-                                    Shared:ListBoxHelper.AutoScrollToCurrentItem="True">
+                                    SharedUi:ListBoxHelper.AutoScrollToCurrentItem="True">
                                 <ListBox.Resources>
 
                                     <Style x:Key="ListBoxItemVariableDefinitionToolTipStyle" TargetType="ToolTip">

--- a/ECUFlasher/ECUInfoControl.xaml
+++ b/ECUFlasher/ECUInfoControl.xaml
@@ -26,7 +26,7 @@ Contact by Email: tony@nefariousmotorsports.com
     xmlns:sys="clr-namespace:System;assembly=mscorlib"
     xmlns:ECUFlasher="clr-namespace:ECUFlasher"
     xmlns:props="clr-namespace:ECUFlasher.Properties"
-    xmlns:Shared="clr-namespace:Shared;assembly=ECUShared"
+    xmlns:SharedUi="clr-namespace:Shared"
     xmlns:Communication="clr-namespace:Communication;assembly=Communication"
     mc:Ignorable="d"
     d:DesignHeight="300" d:DesignWidth="300"
@@ -173,13 +173,13 @@ Contact by Email: tony@nefariousmotorsports.com
 
             <Border Grid.Row="1" Grid.Column="0">
                 <ListBox IsSynchronizedWithCurrentItem="True" Background="Transparent"
-                                        Shared:ListBoxHelper.AutoScrollToCurrentItem="True"
+                                        SharedUi:ListBoxHelper.AutoScrollToCurrentItem="True"
                                         ItemsSource="{Binding Path=CombinedECUInfo}"/>
             </Border>
 
             <Border Grid.Row="1" Grid.Column="2">
                 <ListBox Name="ECUDTCsListBox" IsSynchronizedWithCurrentItem="True" SelectionMode="Extended" ItemsSource="{Binding Path=ECUDTCs}" Background="Transparent"
-                                            Shared:ListBoxHelper.AutoScrollToCurrentItem="True"/>
+                                            SharedUi:ListBoxHelper.AutoScrollToCurrentItem="True"/>
             </Border>
         </Grid>
 

--- a/ECUFlasher/FlashingControl.xaml
+++ b/ECUFlasher/FlashingControl.xaml
@@ -24,7 +24,7 @@ Contact by Email: tony@nefariousmotorsports.com
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:ECUFlasher="clr-namespace:ECUFlasher"
-    xmlns:Shared="clr-namespace:Shared;assembly=ECUShared"
+    xmlns:SharedUi="clr-namespace:Shared"
     xmlns:props="clr-namespace:ECUFlasher.Properties"
     mc:Ignorable="d"
     d:DesignHeight="300" d:DesignWidth="300"
@@ -34,7 +34,7 @@ Contact by Email: tony@nefariousmotorsports.com
 
     <ECUFlasher:BaseUserControl.Resources>
 
-        <Shared:ByteArrayToBitmapConverter x:Key="byteArrayToBitmapConverter"/>
+        <SharedUi:ByteArrayToBitmapConverter x:Key="byteArrayToBitmapConverter"/>
 
     </ECUFlasher:BaseUserControl.Resources>
 

--- a/ECUFlasher/SharedUIUtils.cs
+++ b/ECUFlasher/SharedUIUtils.cs
@@ -40,18 +40,16 @@ using System.Windows.Markup;
 
 namespace Shared
 {
-    public class ExtensionFixer
+    internal static class WpfBindingMap
     {
-        public static string SwitchToLongExtension(string fileName, string shortExt, string longExt)
+        public static object FromLogic(object value)
         {
-            var convertedFileName = fileName;
-
-            if (!fileName.EndsWith(longExt, StringComparison.OrdinalIgnoreCase) && fileName.EndsWith(shortExt, StringComparison.OrdinalIgnoreCase))
+            if (ReferenceEquals(value, BindingSentinels.UnsetValue))
             {
-                convertedFileName = fileName.Replace(shortExt, longExt);
+                return DependencyProperty.UnsetValue;
             }
 
-            return convertedFileName;
+            return value;
         }
     }
 
@@ -59,19 +57,7 @@ namespace Shared
     {
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            if ((value is string) || (value == null))
-            {
-                return value;
-            }
-
-            if ((parameter == null) || !(parameter is string))
-            {
-                return value.ToString();
-            }
-            else
-            {
-                return string.Format(parameter as string, value);
-            }
+            return WpfBindingMap.FromLogic(AsStringConverterLogic.Convert(value, targetType, parameter, culture));
         }
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
@@ -84,24 +70,12 @@ namespace Shared
     {
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            if (value is TimeSpan)
-            {
-                return ((TimeSpan)value).TotalSeconds;
-            }
-
-            return value;//can't convert, let databinding try to handle it
+            return WpfBindingMap.FromLogic(TimeSpanSecondsConverterLogic.Convert(value, targetType, parameter, culture));
         }
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            try
-            {
-                return TimeSpan.FromSeconds((double)value);
-            }
-            catch
-            {
-                return value;//can't convert, let databinding try to handle it
-            }
+            return WpfBindingMap.FromLogic(TimeSpanSecondsConverterLogic.ConvertBack(value, targetType, parameter, culture));
         }
     }
 
@@ -109,34 +83,12 @@ namespace Shared
     {
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            if (value is TimeSpan)
-            {
-                var builder = new StringBuilder();
-
-                var timeSpan = (TimeSpan)value;
-
-                builder.AppendFormat("{0:D2}", timeSpan.Hours);
-                builder.AppendFormat(":{0:D2}", timeSpan.Minutes);
-                builder.AppendFormat(":{0:D2}", timeSpan.Seconds);
-                builder.AppendFormat(".{0:D3}", timeSpan.Milliseconds);
-
-                return builder.ToString();
-            }
-
-            return value;//can't convert, let databinding try to handle it
+            return WpfBindingMap.FromLogic(TimeSpanStringFormatConverterLogic.Convert(value, targetType, parameter, culture));
         }
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            try
-            {
-                var converter = new TimeSpanConverter();
-                return converter.ConvertFrom(value);
-            }
-            catch
-            {
-                return value;//can't convert, let databinding try to handle it
-            }
+            return WpfBindingMap.FromLogic(TimeSpanStringFormatConverterLogic.ConvertBack(value, targetType, parameter, culture));
         }
     }
 
@@ -144,21 +96,12 @@ namespace Shared
     {
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            return DataUtils.WriteHexString(value);
+            return WpfBindingMap.FromLogic(HexConverterLogic.Convert(value, targetType, parameter, culture));
         }
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            if (value != null)
-            {
-                if (value is string)
-                {
-                    var valueString = value as string;
-                    return DataUtils.ReadHexString(valueString);
-                }
-            }
-
-            return value;//can't convert, let databinding try to handle it
+            return WpfBindingMap.FromLogic(HexConverterLogic.ConvertBack(value, targetType, parameter, culture));
         }
     }
 
@@ -166,26 +109,7 @@ namespace Shared
     {
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            string strValue = null;
-
-            if (value != null)
-            {
-                strValue = value.ToString();
-            }
-
-            if (string.IsNullOrEmpty(strValue))
-            {
-                return DependencyProperty.UnsetValue;
-            }
-
-            if (targetType == typeof(Boolean))
-            {
-                return true;
-            }
-            else
-            {
-                return strValue;
-            }
+            return WpfBindingMap.FromLogic(StringValidConverterLogic.Convert(value, targetType, parameter, culture));
         }
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
@@ -218,34 +142,12 @@ namespace Shared
     {
         public static object GetDescriptionAttribute(object value)
         {
-            if (value != null)
-            {
-                var fieldInfo = value.GetType().GetField(value.ToString());
-
-                if (fieldInfo != null)
-                {
-                    var attributes = (DescriptionAttribute[])fieldInfo.GetCustomAttributes(typeof(DescriptionAttribute), false);
-
-                    if (attributes.Length > 0)
-                    {
-                        return attributes[0].Description;
-                    }
-                }
-            }
-
-            return null;
+            return DescriptionAttributeConverterLogic.GetDescriptionAttribute(value);
         }
 
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            var description = GetDescriptionAttribute(value);
-
-            if (description == null)
-            {
-                description = DependencyProperty.UnsetValue;
-            }
-
-            return description;
+            return WpfBindingMap.FromLogic(DescriptionAttributeConverterLogic.Convert(value, targetType, parameter, culture));
         }
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
@@ -516,28 +418,6 @@ namespace Shared
         public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
         {
             throw new NotSupportedException();
-        }
-    }
-
-    [AttributeUsage(AttributeTargets.Field, AllowMultiple = true)]
-    public class ValueMappedDescriptionAttribute : Attribute
-    {
-        public ValueMappedDescriptionAttribute(object value, string description)
-        {
-            Value = value;
-            Description = description;
-        }
-
-        public object Value
-        {
-            get;
-            set;
-        }
-
-        public string Description
-        {
-            get;
-            set;
         }
     }
 

--- a/ECUFlasher/StatusWindow.xaml
+++ b/ECUFlasher/StatusWindow.xaml
@@ -25,7 +25,7 @@ Contact by Email: tony@nefariousmotorsports.com
             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
             xmlns:sys="clr-namespace:System;assembly=mscorlib"
             xmlns:ECUFlasher="clr-namespace:ECUFlasher"
-            xmlns:Shared="clr-namespace:Shared;assembly=ECUShared"
+            xmlns:SharedUi="clr-namespace:Shared"
             mc:Ignorable="d"
             d:DesignHeight="300" d:DesignWidth="300">
     <Grid Margin="5">
@@ -66,6 +66,6 @@ Contact by Email: tony@nefariousmotorsports.com
         </Menu>
         <TextBox Grid.Row="1" Text="{Binding Path=StatusText, Mode=OneWay}" IsReadOnly="True" AllowDrop="False" TextWrapping="WrapWithOverflow"
                         VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" BorderThickness="0"
-                        Shared:AutoScrollTextBox.AutoScrollTextBox="True"/>
+                        SharedUi:AutoScrollTextBox.AutoScrollTextBox="True"/>
     </Grid>
 </UserControl>

--- a/Shared/ConverterLogic.cs
+++ b/Shared/ConverterLogic.cs
@@ -1,0 +1,235 @@
+/*
+Nefarious Motorsports ME7 ECU Flasher
+Copyright (C) 2026  Nefarious Motorsports Inc
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Contact by Email: nyet@nyet.org
+*/
+
+using System;
+using System.ComponentModel;
+using System.Globalization;
+using System.Text;
+
+namespace Shared
+{
+    public static class BindingSentinels
+    {
+        public static readonly object UnsetValue = new object();
+    }
+
+    public class ExtensionFixer
+    {
+        public static string SwitchToLongExtension(string fileName, string shortExt, string longExt)
+        {
+            var convertedFileName = fileName;
+
+            if (!fileName.EndsWith(longExt, StringComparison.OrdinalIgnoreCase) && fileName.EndsWith(shortExt, StringComparison.OrdinalIgnoreCase))
+            {
+                convertedFileName = fileName.Replace(shortExt, longExt);
+            }
+
+            return convertedFileName;
+        }
+    }
+
+    public static class AsStringConverterLogic
+    {
+        public static object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if ((value is string) || (value == null))
+            {
+                return value;
+            }
+
+            if ((parameter == null) || !(parameter is string))
+            {
+                return value.ToString();
+            }
+            else
+            {
+                return string.Format(parameter as string, value);
+            }
+        }
+    }
+
+    public static class TimeSpanSecondsConverterLogic
+    {
+        public static object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is TimeSpan)
+            {
+                return ((TimeSpan)value).TotalSeconds;
+            }
+
+            return value;//can't convert, let databinding try to handle it
+        }
+
+        public static object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            try
+            {
+                return TimeSpan.FromSeconds((double)value);
+            }
+            catch
+            {
+                return value;//can't convert, let databinding try to handle it
+            }
+        }
+    }
+
+    public static class TimeSpanStringFormatConverterLogic
+    {
+        public static object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is TimeSpan)
+            {
+                var builder = new StringBuilder();
+
+                var timeSpan = (TimeSpan)value;
+
+                builder.AppendFormat("{0:D2}", timeSpan.Hours);
+                builder.AppendFormat(":{0:D2}", timeSpan.Minutes);
+                builder.AppendFormat(":{0:D2}", timeSpan.Seconds);
+                builder.AppendFormat(".{0:D3}", timeSpan.Milliseconds);
+
+                return builder.ToString();
+            }
+
+            return value;//can't convert, let databinding try to handle it
+        }
+
+        public static object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            try
+            {
+                var converter = new TimeSpanConverter();
+                return converter.ConvertFrom(value);
+            }
+            catch
+            {
+                return value;//can't convert, let databinding try to handle it
+            }
+        }
+    }
+
+    public static class HexConverterLogic
+    {
+        public static object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            return DataUtils.WriteHexString(value);
+        }
+
+        public static object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value != null)
+            {
+                if (value is string)
+                {
+                    var valueString = value as string;
+                    return DataUtils.ReadHexString(valueString);
+                }
+            }
+
+            return value;//can't convert, let databinding try to handle it
+        }
+    }
+
+    public static class StringValidConverterLogic
+    {
+        public static object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            string strValue = null;
+
+            if (value != null)
+            {
+                strValue = value.ToString();
+            }
+
+            if (string.IsNullOrEmpty(strValue))
+            {
+                return BindingSentinels.UnsetValue;
+            }
+
+            if (targetType == typeof(Boolean))
+            {
+                return true;
+            }
+            else
+            {
+                return strValue;
+            }
+        }
+    }
+
+    public static class DescriptionAttributeConverterLogic
+    {
+        public static object GetDescriptionAttribute(object value)
+        {
+            if (value != null)
+            {
+                var fieldInfo = value.GetType().GetField(value.ToString());
+
+                if (fieldInfo != null)
+                {
+                    var attributes = (DescriptionAttribute[])fieldInfo.GetCustomAttributes(typeof(DescriptionAttribute), false);
+
+                    if (attributes.Length > 0)
+                    {
+                        return attributes[0].Description;
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        public static object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            var description = GetDescriptionAttribute(value);
+
+            if (description == null)
+            {
+                description = BindingSentinels.UnsetValue;
+            }
+
+            return description;
+        }
+    }
+
+    [AttributeUsage(AttributeTargets.Field, AllowMultiple = true)]
+    public class ValueMappedDescriptionAttribute : Attribute
+    {
+        public ValueMappedDescriptionAttribute(object value, string description)
+        {
+            Value = value;
+            Description = description;
+        }
+
+        public object Value
+        {
+            get;
+            set;
+        }
+
+        public string Description
+        {
+            get;
+            set;
+        }
+    }
+}
+
+// vi: set sw=4 ts=8 expandtab:

--- a/Shared/Shared.csproj
+++ b/Shared/Shared.csproj
@@ -4,9 +4,6 @@
     <RootNamespace>ECUShared</RootNamespace>
     <AssemblyName>ECUShared</AssemblyName>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <UseWindowsForms>true</UseWindowsForms>
-    <UseWPF>true</UseWPF>
-    <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <OutputPath>bin\msil\Debug\</OutputPath>

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -42,7 +42,7 @@ build.bat publish
 ## Prerequisites
 
 - **.NET 10 SDK** (preferred) or **Visual Studio** with MSBuild. End users of the MSI need the **.NET 10 Desktop Runtime**, not only the console runtime.
-- Target framework is `NetTfm` in [`Directory.Build.props`](../Directory.Build.props). Output dirs do not include the TFM (`ECUFlasher/bin/msil/Debug` / `Release`).
+- Target framework is `NetTfm` in [`Directory.Build.props`](../Directory.Build.props) (`net10.0`). Shared libraries and tests use that TFM (no WPF). The WPF app is `$(NetTfm)-windows`. `EnableWindowsTargeting` lets non-Windows hosts restore the windows TFM. Output dirs do not include the TFM (`ECUFlasher/bin/msil/Debug` / `Release`).
 - **WiX Toolset** (installer builds; MSI is **x64**, `-arch x64`). Version is [`.config/dotnet-tools.json`](../.config/dotnet-tools.json) (Dependabot can bump it). [`Installer/installer.ps1`](../Installer/installer.ps1) runs `dotnet tool restore` then `dotnet tool run wix` — no global `wix` on `PATH`. `make installer` and `build.bat installer` both invoke that script. UI and NetFx extensions are added at the json version during the installer build.
 
 `make publish` / `build.bat publish` writes a framework-dependent copy to `publish/NefMotoECUFlasher`. It is not a substitute for the MSI: no shortcuts, no installer .NET check, and it still needs the .NET 10 Desktop runtime. `MemoryLayouts` is copied next to the executable. This is not a single-file exe.


### PR DESCRIPTION
Keep core libs free of WPF so a later Avalonia (or other) UI can reference them without multi-targeting Shared. WPF app behavior should be unchanged.

Extract converter/helper logic into Shared/ConverterLogic.cs and git mv Shared/UIUtils.cs to ECUFlasher/SharedUIUtils.cs (do not touch ECUFlasher/UIUtils.cs baud/connection converters).

Drop UseWPF from Shared/Communication; retarget those libs plus Checksum, ApplicationShared, and Tests to net10.0 while ECUFlasher stays net10.0-windows.

Communication uses DescriptionAttributeConverterLogic for programming-precondition text.

Closes #112